### PR TITLE
Add support for persisting ProtectedStoragePayload used for ProposalPayload

### DIFF
--- a/src/main/java/bisq/core/app/SetupUtils.java
+++ b/src/main/java/bisq/core/app/SetupUtils.java
@@ -87,21 +87,18 @@ public class SetupUtils {
 
     public static BooleanProperty readFromResources(P2PDataStorage p2PDataStorage) {
         BooleanProperty result = new SimpleBooleanProperty();
-        Thread thread = new Thread() {
-            @Override
-            public void run() {
-                Thread.currentThread().setName("readFromResourcesThread");
-                // Used to load different files per base currency (EntryMap_BTC_MAINNET, EntryMap_LTC,...)
-                final BaseCurrencyNetwork baseCurrencyNetwork = BisqEnvironment.getBaseCurrencyNetwork();
-                final String storageFileName = "PersistableNetworkPayloadMap_"
-                        + baseCurrencyNetwork.getCurrencyCode() + "_"
-                        + baseCurrencyNetwork.getNetwork();
-                long ts = new Date().getTime();
-                p2PDataStorage.readFromResources(storageFileName);
-                log.info("readPersistableNetworkPayloadMapFromResources took {} ms", (new Date().getTime() - ts));
-                UserThread.execute(() -> result.set(true));
-            }
-        };
+        Thread thread = new Thread(() -> {
+            Thread.currentThread().setName("readFromResourcesThread");
+            // Used to load different files per base currency (EntryMap_BTC_MAINNET, EntryMap_LTC,...)
+            final BaseCurrencyNetwork baseCurrencyNetwork = BisqEnvironment.getBaseCurrencyNetwork();
+            final String postFix = "_" + baseCurrencyNetwork.getCurrencyCode() + "_"
+                    + baseCurrencyNetwork.getNetwork();
+            long ts = new Date().getTime();
+            p2PDataStorage.readFromResources(P2PDataStorage.PERSISTABLE_NETWORK_PAYLOAD_MAP_FILE_NAME, postFix);
+            p2PDataStorage.readFromResources(P2PDataStorage.PERSISTED_ENTRY_MAP_FILE_NAME, postFix);
+            log.info("readFromResources took {} ms", (new Date().getTime() - ts));
+            UserThread.execute(() -> result.set(true));
+        });
         thread.start();
         return result;
     }

--- a/src/main/java/bisq/core/dao/node/full/FullNodeParser.java
+++ b/src/main/java/bisq/core/dao/node/full/FullNodeParser.java
@@ -100,7 +100,7 @@ public class FullNodeParser extends BsqParser {
                 btcdBlock.getPreviousBlockHash(),
                 ImmutableList.copyOf(bsqTxsInBlock));
         bsqBlockController.addBlockIfValid(bsqBlock);
-        log.info("parseBlock took {} ms at blockHeight {}; bsqTxsInBlock.size={}",
+        log.debug("parseBlock took {} ms at blockHeight {}; bsqTxsInBlock.size={}",
                 System.currentTimeMillis() - startTs, bsqBlock.getHeight(), bsqTxsInBlock.size());
         return bsqBlock;
     }
@@ -132,7 +132,7 @@ public class FullNodeParser extends BsqParser {
             txList.add(tx);
             checkForGenesisTx(blockHeight, bsqTxsInBlock, tx);
         }
-        log.info("Requesting {} transactions took {} ms",
+        log.debug("Requesting {} transactions took {} ms",
                 btcdBlock.getTx().size(), System.currentTimeMillis() - startTs);
         // Worst case is that all txs in a block are depending on another, so only one get resolved at each iteration.
         // Min tx size is 189 bytes (normally about 240 bytes), 1 MB can contain max. about 5300 txs (usually 2000).

--- a/src/main/java/bisq/core/dao/node/lite/LiteNodeParser.java
+++ b/src/main/java/bisq/core/dao/node/lite/LiteNodeParser.java
@@ -59,7 +59,7 @@ public class LiteNodeParser extends BsqParser {
 
     void parseBsqBlock(BsqBlock bsqBlock) throws BlockNotConnectingException {
         int blockHeight = bsqBlock.getHeight();
-        log.info("Parse block at height={} ", blockHeight);
+        log.debug("Parse block at height={} ", blockHeight);
         List<Tx> txList = new ArrayList<>(bsqBlock.getTxs());
         List<Tx> bsqTxsInBlock = new ArrayList<>();
         bsqBlock.getTxs().forEach(tx -> checkForGenesisTx(blockHeight, bsqTxsInBlock, tx));

--- a/src/main/java/bisq/core/dao/proposal/ProposalPayload.java
+++ b/src/main/java/bisq/core/dao/proposal/ProposalPayload.java
@@ -28,6 +28,7 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 import bisq.common.app.Capabilities;
 import bisq.common.crypto.Sig;
 import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.persistable.PersistablePayload;
 import bisq.common.util.JsonExclude;
 
 import io.bisq.generated.protobuffer.PB;
@@ -58,8 +59,7 @@ import javax.annotation.Nullable;
  */
 @Slf4j
 @Data
-//TODO removed PersistableProtectedPayload
-public abstract class ProposalPayload implements LazyProcessedPayload, ProtectedStoragePayload, CapabilityRequiringPayload {
+public abstract class ProposalPayload implements LazyProcessedPayload, ProtectedStoragePayload, PersistablePayload, CapabilityRequiringPayload {
     protected final String uid;
     protected final String name;
     protected final String title;

--- a/src/main/java/bisq/core/dao/proposal/ProposalPayload.java
+++ b/src/main/java/bisq/core/dao/proposal/ProposalPayload.java
@@ -23,13 +23,11 @@ import bisq.core.dao.proposal.generic.GenericProposalPayload;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.storage.payload.CapabilityRequiringPayload;
 import bisq.network.p2p.storage.payload.LazyProcessedPayload;
-import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
+import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.app.Capabilities;
-import bisq.common.crypto.Hash;
 import bisq.common.crypto.Sig;
 import bisq.common.proto.ProtobufferException;
-import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.util.JsonExclude;
 
 import io.bisq.generated.protobuffer.PB;
@@ -45,7 +43,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import lombok.Data;
@@ -62,7 +59,7 @@ import javax.annotation.Nullable;
 @Slf4j
 @Data
 //TODO removed PersistableProtectedPayload
-public abstract class ProposalPayload implements LazyProcessedPayload, PersistableNetworkPayload, PersistableEnvelope, CapabilityRequiringPayload {
+public abstract class ProposalPayload implements LazyProcessedPayload, ProtectedStoragePayload, CapabilityRequiringPayload {
     protected final String uid;
     protected final String name;
     protected final String title;
@@ -147,8 +144,9 @@ public abstract class ProposalPayload implements LazyProcessedPayload, Persistab
         return builder;
     }
 
-    public PB.PersistableNetworkPayload toProtoMessage() {
-        return PB.PersistableNetworkPayload.newBuilder().setProposalPayload(getPayloadBuilder()).build();
+    @Override
+    public PB.StoragePayload toProtoMessage() {
+        return PB.StoragePayload.newBuilder().setProposalPayload(getPayloadBuilder()).build();
     }
 
     //TODO add other proposal types
@@ -202,22 +200,4 @@ public abstract class ProposalPayload implements LazyProcessedPayload, Persistab
     }
 
     public abstract ProposalType getType();
-
-    @Override
-    public byte[] getHash() {
-        if (hash == null)
-            // We create hash from all fields excluding hash itself.
-            // We handle hash as nullable in PB methods even it is never null. Using getHash() would create a endless
-            // recursion.
-            // We use lazy setting because if called in constructor it would not include the data fields from the
-            // sub classes as super() is called before setting those.
-            this.hash = Hash.getSha256Ripemd160hash(toProtoMessage().toByteArray());
-
-        return hash;
-    }
-
-    @Override
-    public boolean verifyHashSize() {
-        return Objects.requireNonNull(hash).length == 20;
-    }
 }

--- a/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
+++ b/src/main/java/bisq/core/payment/AccountAgeWitnessService.java
@@ -101,7 +101,7 @@ public class AccountAgeWitnessService {
         });
 
         // At startup the P2PDataStorage initializes earlier, otherwise we ge the listener called.
-        p2PService.getP2PDataStorage().getPersistableNetworkPayloadCollection().getMap().values().forEach(e -> {
+        p2PService.getP2PDataStorage().getPersistableNetworkPayloadList().getMap().values().forEach(e -> {
             if (e instanceof AccountAgeWitness)
                 addToMap((AccountAgeWitness) e);
         });

--- a/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -17,7 +17,6 @@
 
 package bisq.core.proto;
 
-import bisq.core.dao.proposal.ProposalPayload;
 import bisq.core.payment.AccountAgeWitness;
 import bisq.core.payment.payload.AliPayAccountPayload;
 import bisq.core.payment.payload.CashAppAccountPayload;
@@ -139,8 +138,6 @@ public class CoreProtoResolver implements ProtoResolver {
                     return AccountAgeWitness.fromProto(proto.getAccountAgeWitness());
                 case TRADE_STATISTICS2:
                     return TradeStatistics2.fromProto(proto.getTradeStatistics2());
-                case PROPOSAL_PAYLOAD:
-                    return ProposalPayload.fromProto(proto.getProposalPayload());
                 default:
                     throw new ProtobufferException("Unknown proto message case (PB.PersistableNetworkPayload). messageCase=" + proto.getMessageCase());
             }

--- a/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -29,6 +29,7 @@ import bisq.core.arbitration.messages.PeerPublishedDisputePayoutTxMessage;
 import bisq.core.dao.node.messages.GetBsqBlocksRequest;
 import bisq.core.dao.node.messages.GetBsqBlocksResponse;
 import bisq.core.dao.node.messages.NewBsqBlockBroadcastMessage;
+import bisq.core.dao.proposal.ProposalPayload;
 import bisq.core.filter.Filter;
 import bisq.core.offer.OfferPayload;
 import bisq.core.offer.messages.OfferAvailabilityRequest;
@@ -194,6 +195,8 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                     return MailboxStoragePayload.fromProto(proto.getMailboxStoragePayload());
                 case OFFER_PAYLOAD:
                     return OfferPayload.fromProto(proto.getOfferPayload());
+                case PROPOSAL_PAYLOAD:
+                    return ProposalPayload.fromProto(proto.getProposalPayload());
                 default:
                     throw new ProtobufferException("Unknown proto message case (PB.StoragePayload). messageCase=" + proto.getMessageCase());
             }

--- a/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
+++ b/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
@@ -29,7 +29,7 @@ import bisq.core.user.PreferencesPayload;
 import bisq.core.user.UserPayload;
 
 import bisq.network.p2p.peers.peerexchange.PeerList;
-import bisq.network.p2p.storage.PersistableNetworkPayloadCollection;
+import bisq.network.p2p.storage.PersistableNetworkPayloadList;
 import bisq.network.p2p.storage.PersistedEntryMap;
 import bisq.network.p2p.storage.SequenceNumberMap;
 
@@ -102,7 +102,7 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                 case BSQ_BLOCK_CHAIN:
                     return BsqBlockChain.fromProto(proto.getBsqBlockChain());
                 case PERSISTABLE_NETWORK_PAYLOAD_LIST:
-                    return PersistableNetworkPayloadCollection.fromProto(proto.getPersistableNetworkPayloadList(), this);
+                    return PersistableNetworkPayloadList.fromProto(proto.getPersistableNetworkPayloadList(), this);
                 case PROPOSAL_LIST:
                     return ProposalList.fromProto(proto.getProposalList());
                 default:

--- a/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -113,7 +113,7 @@ public class TradeStatisticsManager {
                 addToMap((TradeStatistics2) payload, true);
         });
 
-        p2PService.getP2PDataStorage().getPersistableNetworkPayloadCollection().getMap().values().forEach(e -> {
+        p2PService.getP2PDataStorage().getPersistableNetworkPayloadList().getMap().values().forEach(e -> {
             if (e instanceof TradeStatistics2)
                 addToMap((TradeStatistics2) e, false);
         });


### PR DESCRIPTION
- Add ProposalPayload interface to ProposalPayload
- Add protectedStoragePayload to persistedEntryMap if payload is an instance of PersistablePayload
- Remove protectedStoragePayload from persistedEntryMap if payload is an instance of PersistablePayload
- Rename PersistableNetworkPayloadCollection to PersistableNetworkPayloadList to be in sync with PB definition
- Replace stream().forEach by forEach
- Refactor readFromResources method to pass file name and prost fix separate