### PR TITLE
Fix 10grans CryptoCurrency Parameters

### DIFF
--- a/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -190,7 +190,7 @@ public class CurrencyUtil {
         result.add(new CryptoCurrency("UBQ", "Ubiq"));
         result.add(new CryptoCurrency("QWARK", "Qwark", true));
         result.add(new CryptoCurrency("GEO", "GeoCoin", true));
-        result.add(new CryptoCurrency("GRANS", "10grans"));
+        result.add(new CryptoCurrency("GRANS", "10grans", true));
         result.add(new CryptoCurrency("ICH", "ICH"));
 
         result.sort(TradeCurrency::compareTo);


### PR DESCRIPTION
10grans was merged incorrectly as an altcoin. This commit fixes the currency's listing and changes the listing to reflect its status as an ERC-20 token on the Ubiq Network.