### PR TITLE
Change ticker from STL to XTL for Stellite Altcoin

### DIFF
--- a/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -166,7 +166,7 @@ public class CurrencyUtil {
         result.add(new CryptoCurrency("ZEN", "ZenCash"));
 
         // Added 0.6.6
-        result.add(new CryptoCurrency("STL", "Stellite"));
+        result.add(new CryptoCurrency("XTL", "Stellite"));
         result.add(new CryptoCurrency("DAI", "Dai Stablecoin", true));
         result.add(new CryptoCurrency("YTN", "Yenten"));
         result.add(new CryptoCurrency("DARX", "BitDaric"));

--- a/src/main/java/bisq/core/payment/validation/AltCoinAddressValidator.java
+++ b/src/main/java/bisq/core/payment/validation/AltCoinAddressValidator.java
@@ -439,7 +439,7 @@ public final class AltCoinAddressValidator extends InputValidator {
                         return regexTestFailed;
                     else
                         return new ValidationResult(true);
-                case "STL":
+                case "XTL":
                     if (!input.matches("^(Se)\\d[0-9A-Za-z]{94}$"))
                         return regexTestFailed;
                     else

--- a/src/test/java/bisq/core/payment/validation/AltCoinAddressValidatorTest.java
+++ b/src/test/java/bisq/core/payment/validation/AltCoinAddressValidatorTest.java
@@ -573,9 +573,9 @@ public class AltCoinAddressValidatorTest {
 
     // Added 0.6.6
     @Test
-    public void testSTL() {
+    public void testXTL() {
         AltCoinAddressValidator validator = new AltCoinAddressValidator();
-        validator.setCurrencyCode("STL");
+        validator.setCurrencyCode("XTL");
 
         assertTrue(validator.validate("Se3x7sVdvUnMMn2KoYLyYVHMJGRoB2R3V8K3LYuHAiEXgVac7vsmFiXUC8dSpJnjXDfwytKsQJV6HFH8MjwPagTJ2Aha46RZM").isValid);
         assertTrue(validator.validate("Se3F51UzpbVVnQRx2VNbcjfBoQJfeuyFF353i1jLnCZda9yVN3vy8csbYCESBvf38TFkchH1C1tMY6XHkC8L678K2vLsVZVMU").isValid);


### PR DESCRIPTION
We have changed our ticker from STL to XTL recently to attain ISO 4217 standard and also avoid a possible conflict of ticker with a dead coin named STLCoin on Coin Market Cap.

Thank you!