### PR TITLE
Feature/startup refactoring 2

### DIFF
--- a/src/main/java/bisq/core/CoreExtension.java
+++ b/src/main/java/bisq/core/CoreExtension.java
@@ -1,0 +1,215 @@
+package bisq.core;
+
+import bisq.core.app.AppOptionKeys;
+import bisq.core.app.BisqEnvironment;
+import bisq.core.app.BisqExecutable;
+import bisq.core.app.CoreAppSetup;
+import bisq.core.btc.BtcOptionKeys;
+import bisq.core.btc.RegTestHost;
+import bisq.core.dao.DaoOptionKeys;
+import bisq.core.setup.CoreSetup;
+import bisq.core.util.joptsimple.EnumValueConverter;
+
+import bisq.network.NetworkOptionKeys;
+import bisq.network.p2p.P2PService;
+
+import bisq.common.CommonOptionKeys;
+
+import org.springframework.util.StringUtils;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+
+
+
+import bisq.spi.LoadableExtension;
+
+public class CoreExtension implements LoadableExtension {
+    @Override
+    public void decorateOptionParser(OptionParser parser) {
+        //CommonOptionKeys
+        parser.accepts(CommonOptionKeys.LOG_LEVEL_KEY,
+                description("Log level [OFF, ALL, ERROR, WARN, INFO, DEBUG, TRACE]", BisqEnvironment.LOG_LEVEL_DEFAULT))
+                .withRequiredArg();
+
+        //NetworkOptionKeys
+        parser.accepts(NetworkOptionKeys.SEED_NODES_KEY,
+                description("Override hard coded seed nodes as comma separated list: E.g. rxdkppp3vicnbgqt.onion:8002, mfla72c4igh5ta2t.onion:8002", ""))
+                .withRequiredArg();
+        parser.accepts(NetworkOptionKeys.MY_ADDRESS,
+                description("My own onion address (used for botstrap nodes to exclude itself)", ""))
+                .withRequiredArg();
+        parser.accepts(NetworkOptionKeys.BAN_LIST,
+                description("Nodes to exclude from network connections.", ""))
+                .withRequiredArg();
+        // use a fixed port as arbitrator use that for his ID
+        parser.accepts(NetworkOptionKeys.PORT_KEY,
+                description("Port to listen on", 9999))
+                .withRequiredArg()
+                .ofType(int.class);
+        parser.accepts(NetworkOptionKeys.USE_LOCALHOST_FOR_P2P,
+                description("Use localhost P2P network for development", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(NetworkOptionKeys.MAX_CONNECTIONS,
+                description("Max. connections a peer will try to keep", P2PService.MAX_CONNECTIONS_DEFAULT))
+                .withRequiredArg()
+                .ofType(int.class);
+        parser.accepts(NetworkOptionKeys.SOCKS_5_PROXY_BTC_ADDRESS,
+                description("A proxy address to be used for Bitcoin network. [host:port]", ""))
+                .withRequiredArg();
+        parser.accepts(NetworkOptionKeys.SOCKS_5_PROXY_HTTP_ADDRESS,
+                description("A proxy address to be used for Http requests (should be non-Tor). [host:port]", ""))
+                .withRequiredArg();
+
+        //AppOptionKeys
+        parser.accepts(AppOptionKeys.USER_DATA_DIR_KEY,
+                description("User data directory", BisqEnvironment.DEFAULT_USER_DATA_DIR))
+                .withRequiredArg();
+        parser.accepts(AppOptionKeys.APP_NAME_KEY,
+                description("Application name", BisqEnvironment.DEFAULT_APP_NAME))
+                .withRequiredArg();
+        parser.accepts(AppOptionKeys.MAX_MEMORY,
+                description("Max. permitted memory (used only at headless versions)", 600))
+                .withRequiredArg();
+        parser.accepts(AppOptionKeys.APP_DATA_DIR_KEY,
+                description("Application data directory", BisqEnvironment.DEFAULT_APP_DATA_DIR))
+                .withRequiredArg();
+        parser.accepts(AppOptionKeys.IGNORE_DEV_MSG_KEY,
+                description("If set to true all signed network_messages from bisq developers are ignored " +
+                        "(Global alert, Version update alert, Filters for offers, nodes or trading account data)", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS,
+                description("If that is true all the privileged features which requires a private key to enable it are overridden by a dev key pair " +
+                        "(This is for developers only!)", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(CommonOptionKeys.USE_DEV_MODE,
+                description("Enables dev mode which is used for convenience for developer testing", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(AppOptionKeys.DUMP_STATISTICS,
+                description("If set to true the trade statistics are stored as json file in the data dir.", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(AppOptionKeys.PROVIDERS,
+                description("Custom providers (comma separated)", false))
+                .withRequiredArg();
+
+        //BtcOptionKeys
+        parser.accepts(BtcOptionKeys.BASE_CURRENCY_NETWORK,
+                description("Base currency network", BisqEnvironment.getDefaultBaseCurrencyNetwork().name()))
+                .withRequiredArg()
+                .ofType(String.class);
+        //.withValuesConvertedBy(new EnumValueConverter(String.class));
+        parser.accepts(BtcOptionKeys.REG_TEST_HOST,
+                description("", RegTestHost.DEFAULT))
+                .withRequiredArg()
+                .ofType(RegTestHost.class)
+                .withValuesConvertedBy(new EnumValueConverter(RegTestHost.class));
+        parser.accepts(BtcOptionKeys.BTC_NODES,
+                description("Custom nodes used for BitcoinJ as comma separated IP addresses.", ""))
+                .withRequiredArg();
+        parser.accepts(BtcOptionKeys.USE_TOR_FOR_BTC,
+                description("If set to true BitcoinJ is routed over tor (socks 5 proxy).", ""))
+                .withRequiredArg();
+        parser.accepts(BtcOptionKeys.SOCKS5_DISCOVER_MODE,
+                description("Specify discovery mode for Bitcoin nodes. One or more of: [ADDR, DNS, ONION, ALL]" +
+                        " (comma separated, they get OR'd together). Default value is ALL", "ALL"))
+                .withRequiredArg();
+        parser.accepts(BtcOptionKeys.USE_ALL_PROVIDED_NODES,
+                description("Set to true if connection of bitcoin nodes should include clear net nodes", ""))
+                .withRequiredArg();
+        parser.accepts(BtcOptionKeys.USER_AGENT,
+                description("User agent at btc node connections", ""))
+                .withRequiredArg();
+        parser.accepts(BtcOptionKeys.NUM_CONNECTIONS_FOR_BTC,
+                description("Number of connections to the Bitcoin network", "9"))
+                .withRequiredArg();
+
+
+        //RpcOptionKeys
+        parser.accepts(DaoOptionKeys.RPC_USER,
+                description("Bitcoind rpc username", ""))
+                .withRequiredArg();
+        parser.accepts(DaoOptionKeys.RPC_PASSWORD,
+                description("Bitcoind rpc password", ""))
+                .withRequiredArg();
+        parser.accepts(DaoOptionKeys.RPC_PORT,
+                description("Bitcoind rpc port", ""))
+                .withRequiredArg();
+        parser.accepts(DaoOptionKeys.RPC_BLOCK_NOTIFICATION_PORT,
+                description("Bitcoind rpc port for block notifications", ""))
+                .withRequiredArg();
+        parser.accepts(DaoOptionKeys.DUMP_BLOCKCHAIN_DATA,
+                description("If set to true the blockchain data from RPC requests to Bitcoin Core are stored " +
+                        "as json file in the data dir.", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(DaoOptionKeys.FULL_DAO_NODE,
+                description("If set to true the node requests the blockchain data via RPC requests from Bitcoin Core and " +
+                        "provide the validated BSQ txs to the network. It requires that the other RPC properties are " +
+                        "set as well.", false))
+                .withRequiredArg()
+                .ofType(boolean.class);
+        parser.accepts(DaoOptionKeys.GENESIS_TX_ID,
+                description("Genesis transaction ID when not using the hard coded one", ""))
+                .withRequiredArg();
+        parser.accepts(DaoOptionKeys.GENESIS_BLOCK_HEIGHT,
+                description("Genesis transaction block height when not using the hard coded one", ""))
+                .withRequiredArg();
+        parser.accepts("gui", "Enable GUI").withOptionalArg().ofType(boolean.class).defaultsTo(true);
+    }
+
+    @Override
+    public AbstractModule configure(OptionSet options) {
+        final BisqEnvironment environment = new BisqEnvironment(options);
+//        TODO depending on response from cbeams this line should either stay here or go to setup method
+        BisqExecutable.initAppDir(environment.getProperty(AppOptionKeys.APP_DATA_DIR_KEY));
+        return new CoreModule(new BisqEnvironment(options));
+    }
+
+    public CompletableFuture<Void> setup(Injector injector) {
+        CoreSetup.setup(injector.getInstance(BisqEnvironment.class));
+        final CoreAppSetup desktopAppSetup = injector.getInstance(CoreAppSetup.class);
+        try {
+            desktopAppSetup.initPersistedDataHosts().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> preStart(Injector injector) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void start(Injector injector) {
+        final Thread thread = new Thread(() -> {
+            injector.getInstance(CoreAppSetup.class).initBasicServices();
+        });
+        thread.start();
+    }
+
+    private static String description(String descText, Object defaultValue) {
+        String description = "";
+        if (StringUtils.hasText(descText))
+            description = description.concat(descText);
+        if (defaultValue != null)
+            description = join(" ", description, format("(default: %s)", defaultValue));
+        return description;
+    }
+}

--- a/src/main/java/bisq/core/CoreModule.java
+++ b/src/main/java/bisq/core/CoreModule.java
@@ -1,0 +1,125 @@
+package bisq.core;
+
+import bisq.core.alert.AlertModule;
+import bisq.core.app.AppOptionKeys;
+import bisq.core.app.BisqEnvironment;
+import bisq.core.app.CoreAppSetup;
+import bisq.core.arbitration.ArbitratorModule;
+import bisq.core.btc.BitcoinModule;
+import bisq.core.dao.DaoModule;
+import bisq.core.filter.FilterModule;
+import bisq.core.network.p2p.seed.DefaultSeedNodeRepository;
+import bisq.core.network.p2p.seed.SeedNodeAddressLookup;
+import bisq.core.offer.OfferModule;
+import bisq.core.proto.network.CoreNetworkProtoResolver;
+import bisq.core.proto.persistable.CorePersistenceProtoResolver;
+import bisq.core.trade.TradeModule;
+import bisq.core.user.Preferences;
+import bisq.core.user.User;
+
+import bisq.network.crypto.EncryptionServiceModule;
+import bisq.network.p2p.P2PModule;
+import bisq.network.p2p.network.BridgeAddressProvider;
+import bisq.network.p2p.seed.SeedNodeRepository;
+
+import bisq.common.Clock;
+import bisq.common.CommonOptionKeys;
+import bisq.common.app.AppModule;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.KeyStorage;
+import bisq.common.proto.network.NetworkProtoResolver;
+import bisq.common.proto.persistable.PersistenceProtoResolver;
+import bisq.common.storage.Storage;
+
+import com.google.inject.Singleton;
+import com.google.inject.name.Names;
+
+import java.io.File;
+
+import static com.google.inject.name.Names.named;
+
+public class CoreModule extends AppModule {
+
+    public CoreModule(BisqEnvironment environment) {
+        super(environment);
+    }
+
+    @Override
+    protected void configure() {
+//        TODO BisqEnvironment should be renamed to CoreEnvironment
+        bind(BisqEnvironment.class).toInstance((BisqEnvironment) environment);
+
+        bind(CoreAppSetup.class).in(Singleton.class);
+        bind(KeyStorage.class).in(Singleton.class);
+        bind(KeyRing.class).in(Singleton.class);
+        bind(User.class).in(Singleton.class);
+        bind(Clock.class).in(Singleton.class);
+        bind(Preferences.class).in(Singleton.class);
+        bind(BridgeAddressProvider.class).to(Preferences.class).in(Singleton.class);
+
+        bind(SeedNodeAddressLookup.class).in(Singleton.class);
+        bind(SeedNodeRepository.class).to(DefaultSeedNodeRepository.class).in(Singleton.class);
+
+        File storageDir = new File(environment.getRequiredProperty(Storage.STORAGE_DIR));
+        bind(File.class).annotatedWith(named(Storage.STORAGE_DIR)).toInstance(storageDir);
+
+        File keyStorageDir = new File(environment.getRequiredProperty(KeyStorage.KEY_STORAGE_DIR));
+        bind(File.class).annotatedWith(named(KeyStorage.KEY_STORAGE_DIR)).toInstance(keyStorageDir);
+
+        bind(NetworkProtoResolver.class).to(CoreNetworkProtoResolver.class).in(Singleton.class);
+        bind(PersistenceProtoResolver.class).to(CorePersistenceProtoResolver.class).in(Singleton.class);
+
+        Boolean useDevPrivilegeKeys = environment.getProperty(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS, Boolean.class, false);
+        bind(boolean.class).annotatedWith(Names.named(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS)).toInstance(useDevPrivilegeKeys);
+
+        Boolean useDevMode = environment.getProperty(CommonOptionKeys.USE_DEV_MODE, Boolean.class, false);
+        bind(boolean.class).annotatedWith(Names.named(CommonOptionKeys.USE_DEV_MODE)).toInstance(useDevMode);
+
+        // ordering is used for shut down sequence
+        install(tradeModule());
+        install(encryptionServiceModule());
+        install(arbitratorModule());
+        install(offerModule());
+        install(p2pModule());
+        install(bitcoinModule());
+        install(daoModule());
+        install(alertModule());
+        install(filterModule());
+    }
+
+    private TradeModule tradeModule() {
+        return new TradeModule(environment);
+    }
+
+    private EncryptionServiceModule encryptionServiceModule() {
+        return new EncryptionServiceModule(environment);
+    }
+
+    private ArbitratorModule arbitratorModule() {
+        return new ArbitratorModule(environment);
+    }
+
+    private AlertModule alertModule() {
+        return new AlertModule(environment);
+    }
+
+    private FilterModule filterModule() {
+        return new FilterModule(environment);
+    }
+
+    private OfferModule offerModule() {
+        return new OfferModule(environment);
+    }
+
+    private P2PModule p2pModule() {
+        return new P2PModule(environment);
+    }
+
+    private BitcoinModule bitcoinModule() {
+        return new BitcoinModule(environment);
+    }
+
+    private DaoModule daoModule() {
+        return new DaoModule(environment);
+    }
+}

--- a/src/main/java/bisq/core/app/AppSetup.java
+++ b/src/main/java/bisq/core/app/AppSetup.java
@@ -17,43 +17,99 @@
 
 package bisq.core.app;
 
+import bisq.core.setup.CorePersistedDataHost;
+
 import bisq.network.crypto.EncryptionService;
+import bisq.network.p2p.P2PService;
 
 import bisq.common.app.Version;
 import bisq.common.crypto.KeyRing;
+import bisq.common.proto.persistable.PersistedDataHost;
+
+import com.google.inject.Injector;
 
 import javax.inject.Inject;
+
+import java.util.concurrent.CompletableFuture;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class AppSetup {
-    protected final EncryptionService encryptionService;
+    private final EncryptionService encryptionService;
+    private final Injector injector;
     protected final KeyRing keyRing;
+    private final P2PService p2PService;
+    private CompletableFuture<Void> checkCryptoSetupResult;
+    private CompletableFuture<Void> initPersistedDataHostsResult;
+    private CompletableFuture<Void> initBasicServicesResult;
+    private CompletableFuture<Void> readFromResourcesResult;
 
     @Inject
     public AppSetup(EncryptionService encryptionService,
-                    KeyRing keyRing) {
+                    Injector injector,
+                    KeyRing keyRing,
+                    P2PService p2PService) {
         // we need to reference it so the seed node stores tradeStatistics
         this.encryptionService = encryptionService;
+        this.injector = injector;
         this.keyRing = keyRing;
+        this.p2PService = p2PService;
 
         Version.setBaseCryptoNetworkId(BisqEnvironment.getBaseCurrencyNetwork().ordinal());
         Version.printVersion();
     }
 
-    public void start() {
-        SetupUtils.checkCryptoSetup(keyRing, encryptionService, () -> {
-            initPersistedDataHosts();
-            initBasicServices();
-        }, throwable -> {
+    private CompletableFuture<Void> checkCryptoSetup() {
+        if (null != checkCryptoSetupResult)
+            return checkCryptoSetupResult;
+
+        checkCryptoSetupResult = new CompletableFuture<>();
+
+        SetupUtils.checkCryptoSetup(keyRing, encryptionService, () -> checkCryptoSetupResult.complete(null), throwable -> {
             log.error(throwable.getMessage());
             throwable.printStackTrace();
+            checkCryptoSetupResult.completeExceptionally(throwable);
             System.exit(1);
         });
+
+        return checkCryptoSetupResult;
     }
 
-    abstract void initPersistedDataHosts();
+    public CompletableFuture<Void> initPersistedDataHosts() {
+        if (null != initPersistedDataHostsResult)
+            return initPersistedDataHostsResult;
+        initPersistedDataHostsResult = checkCryptoSetup()
+                .thenRun(this::doInitPersistedDataHosts);
+        return initPersistedDataHostsResult;
+    }
 
-    abstract void initBasicServices();
+    protected CompletableFuture<Void> readFromResources() {
+        if (null != readFromResourcesResult)
+            return readFromResourcesResult;
+        readFromResourcesResult = new CompletableFuture<>();
+        SetupUtils.readFromResources(p2PService.getP2PDataStorage()).addListener((observable, oldValue, newValue) -> {
+            if (!newValue) return;
+            readFromResourcesResult.complete(null);
+        });
+        return readFromResourcesResult;
+    }
+
+    private void doInitPersistedDataHosts() {
+        log.debug("doInitPersistedDataHosts");
+        PersistedDataHost.apply(CorePersistedDataHost.getPersistedDataHosts(injector));
+    }
+
+    public CompletableFuture<Void> initBasicServices() {
+        if (null == initBasicServicesResult)
+            initBasicServicesResult = initPersistedDataHosts()
+                    .thenCompose(r -> this.doInitBasicServices())
+                    .thenRun(this::onBasicServicesInitialized);
+        return initBasicServicesResult;
+    }
+
+    protected abstract CompletableFuture<Void> doInitBasicServices();
+
+    protected abstract void onBasicServicesInitialized();
+
 }

--- a/src/main/java/bisq/core/app/AppSetup.java
+++ b/src/main/java/bisq/core/app/AppSetup.java
@@ -17,99 +17,43 @@
 
 package bisq.core.app;
 
-import bisq.core.setup.CorePersistedDataHost;
-
 import bisq.network.crypto.EncryptionService;
-import bisq.network.p2p.P2PService;
 
 import bisq.common.app.Version;
 import bisq.common.crypto.KeyRing;
-import bisq.common.proto.persistable.PersistedDataHost;
-
-import com.google.inject.Injector;
 
 import javax.inject.Inject;
-
-import java.util.concurrent.CompletableFuture;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class AppSetup {
-    private final EncryptionService encryptionService;
-    private final Injector injector;
+    protected final EncryptionService encryptionService;
     protected final KeyRing keyRing;
-    private final P2PService p2PService;
-    private CompletableFuture<Void> checkCryptoSetupResult;
-    private CompletableFuture<Void> initPersistedDataHostsResult;
-    private CompletableFuture<Void> initBasicServicesResult;
-    private CompletableFuture<Void> readFromResourcesResult;
 
     @Inject
     public AppSetup(EncryptionService encryptionService,
-                    Injector injector,
-                    KeyRing keyRing,
-                    P2PService p2PService) {
+                    KeyRing keyRing) {
         // we need to reference it so the seed node stores tradeStatistics
         this.encryptionService = encryptionService;
-        this.injector = injector;
         this.keyRing = keyRing;
-        this.p2PService = p2PService;
 
         Version.setBaseCryptoNetworkId(BisqEnvironment.getBaseCurrencyNetwork().ordinal());
         Version.printVersion();
     }
 
-    private CompletableFuture<Void> checkCryptoSetup() {
-        if (null != checkCryptoSetupResult)
-            return checkCryptoSetupResult;
-
-        checkCryptoSetupResult = new CompletableFuture<>();
-
-        SetupUtils.checkCryptoSetup(keyRing, encryptionService, () -> checkCryptoSetupResult.complete(null), throwable -> {
+    public void start() {
+        SetupUtils.checkCryptoSetup(keyRing, encryptionService, () -> {
+            initPersistedDataHosts();
+            initBasicServices();
+        }, throwable -> {
             log.error(throwable.getMessage());
             throwable.printStackTrace();
-            checkCryptoSetupResult.completeExceptionally(throwable);
             System.exit(1);
         });
-
-        return checkCryptoSetupResult;
     }
 
-    public CompletableFuture<Void> initPersistedDataHosts() {
-        if (null != initPersistedDataHostsResult)
-            return initPersistedDataHostsResult;
-        initPersistedDataHostsResult = checkCryptoSetup()
-                .thenRun(this::doInitPersistedDataHosts);
-        return initPersistedDataHostsResult;
-    }
+    abstract void initPersistedDataHosts();
 
-    protected CompletableFuture<Void> readFromResources() {
-        if (null != readFromResourcesResult)
-            return readFromResourcesResult;
-        readFromResourcesResult = new CompletableFuture<>();
-        SetupUtils.readFromResources(p2PService.getP2PDataStorage()).addListener((observable, oldValue, newValue) -> {
-            if (!newValue) return;
-            readFromResourcesResult.complete(null);
-        });
-        return readFromResourcesResult;
-    }
-
-    private void doInitPersistedDataHosts() {
-        log.debug("doInitPersistedDataHosts");
-        PersistedDataHost.apply(CorePersistedDataHost.getPersistedDataHosts(injector));
-    }
-
-    public CompletableFuture<Void> initBasicServices() {
-        if (null == initBasicServicesResult)
-            initBasicServicesResult = initPersistedDataHosts()
-                    .thenCompose(r -> this.doInitBasicServices())
-                    .thenRun(this::onBasicServicesInitialized);
-        return initBasicServicesResult;
-    }
-
-    protected abstract CompletableFuture<Void> doInitBasicServices();
-
-    protected abstract void onBasicServicesInitialized();
-
+    abstract void initBasicServices();
 }

--- a/src/main/java/bisq/core/app/CoreAppSetup.java
+++ b/src/main/java/bisq/core/app/CoreAppSetup.java
@@ -1,0 +1,257 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.app;
+
+import bisq.core.arbitration.ArbitratorManager;
+import bisq.core.arbitration.DisputeManager;
+import bisq.core.btc.AddressEntry;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.btc.wallet.WalletsSetup;
+import bisq.core.filter.FilterManager;
+import bisq.core.offer.OpenOffer;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.payment.AccountAgeWitnessService;
+import bisq.core.payment.payload.PaymentMethod;
+import bisq.core.provider.fee.FeeService;
+import bisq.core.provider.price.PriceFeedService;
+import bisq.core.trade.TradeManager;
+import bisq.core.trade.statistics.TradeStatisticsManager;
+
+import bisq.network.crypto.EncryptionService;
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.P2PServiceListener;
+import bisq.network.p2p.network.CloseConnectionReason;
+import bisq.network.p2p.network.Connection;
+import bisq.network.p2p.network.ConnectionListener;
+
+import bisq.common.app.Version;
+import bisq.common.crypto.KeyRing;
+
+import com.google.inject.Injector;
+
+import javax.inject.Inject;
+
+import org.fxmisc.easybind.EasyBind;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CoreAppSetup extends AppSetup {
+
+
+    private final DisputeManager disputeManager;
+    private final TradeManager tradeManager;
+    private final OpenOfferManager openOfferManager;
+    private final ArbitratorManager arbitratorManager;
+    private final FeeService feeService;
+    private final PriceFeedService priceFeedService;
+    private final BtcWalletService btcWalletService;
+    private final WalletsSetup walletsSetup;
+    private final P2PService p2PService;
+    private final TradeStatisticsManager tradeStatisticsManager;
+    private final AccountAgeWitnessService accountAgeWitnessService;
+    private final FilterManager filterManager;
+
+    private BooleanProperty walletInitialized;
+    private ObjectProperty<Throwable> walletServiceException;
+
+    @Inject
+    public CoreAppSetup(EncryptionService encryptionService,
+                        KeyRing keyRing,
+                        P2PService p2PService,
+                        TradeStatisticsManager tradeStatisticsManager,
+                        AccountAgeWitnessService accountAgeWitnessService,
+                        FilterManager filterManager,
+                        Injector injector,
+                        ArbitratorManager arbitratorManager,
+                        BtcWalletService btcWalletService,
+                        FeeService feeService,
+                        PriceFeedService priceFeedService,
+                        OpenOfferManager openOfferManager,
+                        TradeManager tradeManager,
+                        DisputeManager disputeManager,
+                        WalletsSetup walletsSetup
+    ) {
+        super(encryptionService, injector, keyRing, p2PService);
+        this.p2PService = p2PService;
+        this.tradeStatisticsManager = tradeStatisticsManager;
+        this.accountAgeWitnessService = accountAgeWitnessService;
+        this.filterManager = filterManager;
+        this.disputeManager = disputeManager;
+        this.tradeManager = tradeManager;
+        this.openOfferManager = openOfferManager;
+        this.arbitratorManager = arbitratorManager;
+        this.feeService = feeService;
+        this.priceFeedService = priceFeedService;
+        this.btcWalletService = btcWalletService;
+        this.walletsSetup = walletsSetup;
+
+        walletInitialized = new SimpleBooleanProperty();
+        walletServiceException = new SimpleObjectProperty<>();
+    }
+
+    @Override
+    protected CompletableFuture<Void> doInitBasicServices() {
+        return readFromResources().thenCompose(i -> {
+            final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            final BooleanProperty p2pNetWorkReady = initP2PNetwork();
+            p2pNetWorkReady.addListener((observable1, oldValue1, newValue1) -> {
+                if (!newValue1) return;
+                initWalletService();
+            });
+            EasyBind.combine(walletInitialized, p2pNetWorkReady,
+                    (a, b) -> {
+                        log.debug("\nwalletInitialized={}\n" +
+                                        "p2pNetWorkReady={}",
+                                a, b);
+                        return a && b;
+                    }).addListener((observable1, oldValue1, newValue1) -> {
+                if (newValue1)
+                    completableFuture.complete(null);
+            });
+            return completableFuture;
+        });
+    }
+
+    private void initWalletService() {
+        walletsSetup.initialize(null).thenRun(() -> {
+            log.debug("walletsSetup.onInitialized");
+            walletInitialized.set(true);
+        }).exceptionally(e -> {
+            walletServiceException.set(e);
+            return null;
+        });
+    }
+
+    @Override
+    protected void onBasicServicesInitialized() {
+        log.debug("onBasicServicesInitialized");
+        PaymentMethod.onAllServicesInitialized();
+        p2PService.onAllServicesInitialized();
+        tradeStatisticsManager.onAllServicesInitialized();
+        accountAgeWitnessService.onAllServicesInitialized();
+        filterManager.onAllServicesInitialized();
+        disputeManager.onAllServicesInitialized();
+        tradeManager.onAllServicesInitialized();
+        openOfferManager.onAllServicesInitialized();
+        arbitratorManager.onAllServicesInitialized();
+        feeService.onAllServicesInitialized();
+        priceFeedService.setCurrencyCodeOnInit();
+
+        swapPendingOfferFundingEntries();
+        checkIfOpenOffersMatchTradeProtocolVersion();
+    }
+
+    private void swapPendingOfferFundingEntries() {
+        tradeManager.getAddressEntriesForAvailableBalanceStream()
+                .filter(addressEntry -> addressEntry.getOfferId() != null)
+                .forEach(addressEntry -> {
+                    log.debug("swapPendingOfferFundingEntries, offerId={}, OFFER_FUNDING", addressEntry.getOfferId());
+                    btcWalletService.swapTradeEntryToAvailableEntry(addressEntry.getOfferId(), AddressEntry.Context.OFFER_FUNDING);
+                });
+    }
+
+    private void checkIfOpenOffersMatchTradeProtocolVersion() {
+        List<OpenOffer> outDatedOffers = openOfferManager.getObservableList()
+                .stream()
+                .filter(e -> e.getOffer().getProtocolVersion() != Version.TRADE_PROTOCOL_VERSION)
+                .collect(Collectors.toList());
+        if (!outDatedOffers.isEmpty()) {
+            openOfferManager.removeOpenOffers(outDatedOffers, null);
+        }
+    }
+
+    private BooleanProperty initP2PNetwork() {
+        log.debug("initP2PNetwork");
+        p2PService.getNetworkNode().addConnectionListener(new ConnectionListener() {
+            @Override
+            public void onConnection(Connection connection) {
+            }
+
+            @Override
+            public void onDisconnect(CloseConnectionReason closeConnectionReason, Connection connection) {
+                // We only check at seed nodes as they are running the latest version
+                // Other disconnects might be caused by peers running an older version
+                if (connection.getPeerType() == Connection.PeerType.SEED_NODE &&
+                        closeConnectionReason == CloseConnectionReason.RULE_VIOLATION) {
+                    log.warn("RULE_VIOLATION onDisconnect closeConnectionReason=" + closeConnectionReason);
+                    log.warn("RULE_VIOLATION onDisconnect connection=" + connection);
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+            }
+        });
+
+        final BooleanProperty p2pNetworkInitialized = new SimpleBooleanProperty();
+        p2PService.start(new P2PServiceListener() {
+            @Override
+            public void onTorNodeReady() {
+                log.debug("onTorNodeReady");
+            }
+
+            @Override
+            public void onHiddenServicePublished() {
+                log.debug("onHiddenServicePublished");
+            }
+
+            @Override
+            public void onDataReceived() {
+                log.debug("onRequestingDataCompleted");
+                p2pNetworkInitialized.set(true);
+            }
+
+            @Override
+            public void onNoSeedNodeAvailable() {
+                log.debug("onNoSeedNodeAvailable");
+                p2pNetworkInitialized.set(true);
+            }
+
+            @Override
+            public void onNoPeersAvailable() {
+                log.debug("onNoPeersAvailable");
+                p2pNetworkInitialized.set(true);
+            }
+
+            @Override
+            public void onUpdatedDataReceived() {
+            }
+
+            @Override
+            public void onSetupFailed(Throwable throwable) {
+                log.error(throwable.toString());
+            }
+
+            @Override
+            public void onRequestCustomBridges() {
+                log.debug("onRequestCustomBridges");
+            }
+        });
+        return p2pNetworkInitialized;
+    }
+}

--- a/src/main/java/bisq/core/app/Main.java
+++ b/src/main/java/bisq/core/app/Main.java
@@ -1,0 +1,118 @@
+package bisq.core.app;
+
+import bisq.common.setup.CommonSetup;
+import bisq.common.util.Utilities;
+
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Singleton;
+import com.google.inject.name.Names;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.StreamSupport;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+
+import bisq.spi.LoadableExtension;
+
+@Slf4j
+public class Main {
+
+    private final ServiceLoader<LoadableExtension> loader;
+
+    public static void main(String[] args) throws Exception {
+        // Need to set default locale initially otherwise we get problems at non-english OS
+        Locale.setDefault(new Locale("en", Locale.getDefault().getCountry()));
+        Utilities.removeCryptographyRestrictions();
+
+//        TODO BisqAppMain initiates bisqEnv then initiates app dir and then once again initiates bisqEnv
+//        TODO BisqAppMain main method also sets context classloader to current thread (some javafx quirks)
+        Thread.currentThread().setContextClassLoader(Main.class.getClassLoader());
+        new Main().run(args);
+    }
+
+    public Main() {
+        loader = ServiceLoader.load(LoadableExtension.class);
+    }
+
+    private void run(String[] args) throws IOException {
+        final OptionSet optionSet = parseOptions(args);
+        final AbstractModule aggregatedModule = constructAggregatedModule(optionSet);
+        final Injector injector = Guice.createInjector(aggregatedModule);
+        injector.getInstance(Key.get(File.class,Names.named("storageDir"))) ;
+        final UncaughtExceptionBroadcaster uncaughtExceptionBroadcaster = injector.getInstance(UncaughtExceptionBroadcaster.class);
+        uncaughtExceptionBroadcaster.addExceptionHandler(this::handleError);
+        CommonSetup.setup(uncaughtExceptionBroadcaster::broadcast);
+        setup(injector);
+        preStart(injector);
+        start(injector);
+    }
+
+    private void handleError(Throwable throwable, Boolean doShutDown) {
+        final String message = throwable.getMessage();
+        final String messageToLog = null == message ? throwable.toString() : message;
+        log.error(messageToLog, throwable);
+    }
+
+    private OptionSet parseOptions(String[] args) throws IOException {
+        final OptionParser parser = decorateOptionParser();
+        OptionSet optionSet;
+        try {
+            optionSet = parser.parse(args);
+            return optionSet;
+        } catch (OptionException e) {
+            System.err.println(e.getMessage());
+            parser.printHelpOn(System.err);
+            System.exit(1);
+            return null;
+        }
+    }
+
+    private OptionParser decorateOptionParser() {
+        final OptionParser parser = new OptionParser();
+        loader.forEach(extension -> extension.decorateOptionParser(parser));
+        return parser;
+    }
+
+    private AbstractModule constructAggregatedModule(final OptionSet optionSet) {
+        return new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(UncaughtExceptionBroadcaster.class).in(Singleton.class);
+                loader.forEach(extension -> install(extension.configure(optionSet)));
+            }
+        };
+    }
+
+    private void setup(Injector injector) {
+//        TODO probably here we should setup extensions in separate threads
+        StreamSupport.stream(loader.spliterator(), true).map(i -> i.setup(injector))
+                .map(CompletableFuture::join)
+                .count();
+    }
+
+    private void preStart(Injector injector) {
+//        TODO probably here we should preStart extensions in separate threads
+        StreamSupport.stream(loader.spliterator(), true).map(i -> i.preStart(injector))
+                .map(CompletableFuture::join)
+                .count();
+    }
+
+    private void start(Injector injector) {
+//        TODO probably here we should start extensions in separate threads
+        loader.forEach(extension -> extension.start(injector));
+    }
+}

--- a/src/main/java/bisq/core/app/SetupUtils.java
+++ b/src/main/java/bisq/core/app/SetupUtils.java
@@ -24,7 +24,6 @@ import bisq.network.crypto.EncryptionService;
 import bisq.network.p2p.peers.keepalive.messages.Ping;
 import bisq.network.p2p.storage.P2PDataStorage;
 
-import bisq.common.UserThread;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.SealedAndSigned;
@@ -68,7 +67,7 @@ public class SetupUtils {
                         log.debug("Crypto test succeeded");
 
                         if (Security.getProvider("BC") != null) {
-                            UserThread.execute(resultHandler::handleResult);
+                            resultHandler.handleResult();
                         } else {
                             errorHandler.accept(new CryptoException("Security provider BountyCastle is not available."));
                         }
@@ -97,7 +96,7 @@ public class SetupUtils {
             p2PDataStorage.readFromResources(P2PDataStorage.PERSISTABLE_NETWORK_PAYLOAD_MAP_FILE_NAME, postFix);
             p2PDataStorage.readFromResources(P2PDataStorage.PERSISTED_ENTRY_MAP_FILE_NAME, postFix);
             log.info("readFromResources took {} ms", (new Date().getTime() - ts));
-            UserThread.execute(() -> result.set(true));
+            result.set(true);
         });
         thread.start();
         return result;

--- a/src/main/java/bisq/core/app/UncaughtExceptionBroadcaster.java
+++ b/src/main/java/bisq/core/app/UncaughtExceptionBroadcaster.java
@@ -1,0 +1,17 @@
+package bisq.core.app;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+public class UncaughtExceptionBroadcaster {
+    private Set<BiConsumer<Throwable, Boolean>> handlers = new HashSet<>();
+
+    public void addExceptionHandler(BiConsumer<Throwable, Boolean> handler) {
+        this.handlers.add(handler);
+    }
+
+    public void broadcast(Throwable throwable, Boolean doShutDown) {
+         handlers.forEach(handler-> handler.accept(throwable,doShutDown));
+    }
+}

--- a/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
+++ b/src/main/java/bisq/core/setup/CoreNetworkCapabilities.java
@@ -35,7 +35,7 @@ public class CoreNetworkCapabilities {
                 Capabilities.Capability.BLIND_VOTE.ordinal()
         ));
 
-        Boolean fullDaoNode = bisqEnvironment.getProperty(DaoOptionKeys.FULL_DAO_NODE, Boolean.class);
+        Boolean fullDaoNode = bisqEnvironment.getProperty(DaoOptionKeys.FULL_DAO_NODE, Boolean.class, false);
         if (fullDaoNode)
             supportedCapabilities.add(Capabilities.Capability.DAO_FULL_NODE.ordinal());
 

--- a/src/main/java/bisq/spi/LoadableExtension.java
+++ b/src/main/java/bisq/spi/LoadableExtension.java
@@ -1,0 +1,23 @@
+package bisq.spi;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface LoadableExtension {
+
+    void decorateOptionParser(OptionParser parser);
+
+    AbstractModule configure(OptionSet options);
+
+    CompletableFuture<Void> preStart(Injector injector);
+
+    CompletableFuture<Void> setup(Injector injector);
+
+    void start(Injector injector);
+
+}

--- a/src/main/resources/META-INF/services/bisq.spi.LoadableExtension
+++ b/src/main/resources/META-INF/services/bisq.spi.LoadableExtension
@@ -1,0 +1,1 @@
+bisq.core.CoreExtension


### PR DESCRIPTION
This is just a proposition of startup refactoring.

The startup process is very complex and requires doing things in right order and often wait for different components to complete specific step in order to proceed.

The key benefit of the proposed approach is that there is just one Main class now. There is no need to have a duplicate in Api or Desktop. With a little extra work it could be reused in monitor, seednode, and statsnode.
It's not only the single, reusable Main class but also Environment. We can now have CoreEnvironment (currently named BiseEnvironment), ApiAnvironment, DesktopEnvironment, etc.
We do not need one big monster that declares/parses/interprets all program options. 

The reason for having core startup as CoreExtension is because it perfectly fits the flow and keeps generic startup logic separated from core startup. 
It can be loaded using ServiceProvider mechanism or could be instantiated in Main. My preference is to keep it as loadable service. Maybe the `Extension` suffix is not the luckiest one, but that is a minor thing and no problem to rename it.
Basically, it's something that needs to be loaded in Bisq aware manner (appropriate steps at the appropriate time).

Have a look at https://github.com/bisq-network/bisq-desktop/pull/1513/files#diff-447d11849e8a6544805965e8f98176c7 how easy it is to hook UI into this flow. The same goes for API and future gRPC component.

Just like Desktop does not need its own Main class, the Api and gRPC won't need either. It makes development and keeping up to date so much easier.