### PR TITLE
List Mazacoin (MAZA)

### DIFF
--- a/src/main/java/bisq/asset/coins/Mazacoin.java
+++ b/src/main/java/bisq/asset/coins/Mazacoin.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AddressValidationResult;
+import bisq.asset.Base58BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class Mazacoin extends Coin {
+
+    public Mazacoin() {
+        super("Mazacoin", "MAZA", new MazacoinAddressValidator());
+    }
+
+
+    public static class MazacoinAddressValidator extends Base58BitcoinAddressValidator {
+
+        public MazacoinAddressValidator() {
+            super(new MazacoinParams());
+        }
+
+        @Override
+        public AddressValidationResult validate(String address) {
+            if (!address.matches("^[M][a-km-zA-HJ-NP-Z1-9]{25,34}$"))
+                return AddressValidationResult.invalidStructure();
+
+            return super.validate(address);
+        }
+    }
+
+
+    public static class MazacoinParams extends NetworkParametersAdapter {
+
+        public MazacoinParams() {
+            addressHeader = 50;
+            p2shHeader = 9;
+            acceptableAddressCodes = new int[]{addressHeader, p2shHeader};
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -56,6 +56,7 @@ bisq.asset.coins.Madbyte
 bisq.asset.coins.Madcoin
 bisq.asset.coins.MaidSafeCoin
 bisq.asset.coins.MFCoin
+bisq.asset.coins.Mazacoin
 bisq.asset.coins.Monero
 bisq.asset.coins.Namecoin
 bisq.asset.coins.NavCoin

--- a/src/test/java/bisq/asset/coins/MazacoinTest.java
+++ b/src/test/java/bisq/asset/coins/MazacoinTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.Test;
+
+public class MazacoinTest extends AbstractAssetTest {
+
+    public MazacoinTest() {
+        super(new Mazacoin());
+    }
+
+    @Test
+    public void testValidAddresses() {
+        assertValidAddress("MQHa9PpncezRRyZ7bMeCi2q5TFgQcxBcxL");
+        assertValidAddress("MU7YNFPziMRWxCYG3JXJnSsGjPXQNBfxRa");
+        assertValidAddress("MSGqB5FYyaZddVKzEAE4rykvBaLT2XQBb5");
+        assertValidAddress("ME8wE7VJTVT8AT4xrB4UM1bBUyEJaqVVh2");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemqq");
+        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYheO");
+        assertInvalidAddress("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhek#");
+    }
+}


### PR DESCRIPTION
Official project URL : www.mazacoin.org
Official Block Explorer: http://explorer.cryptoadhd.com:2750/chain/Mazacoin
