### PR TITLE
Lower minimum withdrawal fee to 1 satoshi per byte

### DIFF
--- a/src/main/java/bisq/core/btc/BaseCurrencyNetwork.java
+++ b/src/main/java/bisq/core/btc/BaseCurrencyNetwork.java
@@ -86,7 +86,7 @@ public enum BaseCurrencyNetwork {
     public long getDefaultMinFeePerByte() {
         switch (BisqEnvironment.getBaseCurrencyNetwork().getCurrencyCode()) {
             case "BTC":
-                return FeeService.BTC_REFERENCE_DEFAULT_MIN_TX_FEE_PER_KB.divide(1000).value;
+                return 1;
             case "LTC":
                 return FeeService.LTC_REFERENCE_DEFAULT_MIN_TX_FEE.value;
             case "DASH":


### PR DESCRIPTION
Previously, the minimum withdrawal fee was 5 sat/byte, but since the
mempool has been empty for months now, it is no longer necessary to
impose a lower bound at all, because 1 sat/byte transactions clear
easily, usually in one block.

We may re-institute a higher minimum in a future version if and when
the mempool becomes consistently backlogged again. But for now, there's
no sense in forcing users to pay more than is necessary to withdraw
coins from their Bisq wallets.