### PR TITLE
[WIP] Round volume of fiat amounts

### DIFF
--- a/src/main/java/bisq/core/monetary/Price.java
+++ b/src/main/java/bisq/core/monetary/Price.java
@@ -18,6 +18,7 @@
 package bisq.core.monetary;
 
 import bisq.core.locale.CurrencyUtil;
+import bisq.core.util.CoinUtil;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
@@ -57,12 +58,15 @@ public class Price extends MonetaryWrapper implements Comparable<Price> {
     }
 
     public Volume getVolumeByAmount(Coin amount) {
-        if (monetary instanceof Fiat)
-            return new Volume(new ExchangeRate((Fiat) monetary).coinToFiat(amount));
-        else if (monetary instanceof Altcoin)
+        if (monetary instanceof Fiat) {
+            final Fiat fiat = new ExchangeRate((Fiat) this.monetary).coinToFiat(amount);
+            Volume volume = new Volume(fiat);
+            return CoinUtil.roundVolume(volume);
+        } else if (monetary instanceof Altcoin) {
             return new Volume(new AltcoinExchangeRate((Altcoin) monetary).coinToAltcoin(amount));
-        else
+        } else {
             throw new IllegalStateException("Monetary must be either of type Fiat or Altcoin");
+        }
     }
 
     public Coin getAmountByVolume(Volume volume) {

--- a/src/main/java/bisq/core/offer/Offer.java
+++ b/src/main/java/bisq/core/offer/Offer.java
@@ -27,6 +27,7 @@ import bisq.core.offer.availability.OfferAvailabilityProtocol;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.provider.price.MarketPrice;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.util.CoinUtil;
 
 import bisq.network.p2p.NodeAddress;
 
@@ -225,12 +226,8 @@ public class Offer implements NetworkPayload, PersistablePayload {
     public Volume getVolumeByAmount(Coin amount) {
         Price price = getPrice();
         if (price != null && amount != null) {
-            // try {
-            return price.getVolumeByAmount(amount);
-           /* } catch (Throwable t) {
-                log.error("getVolumeByAmount failed. Error=" + t.getMessage());
-                return null;
-            }*/
+            final Volume volumeByAmount = price.getVolumeByAmount(amount);
+            return CoinUtil.roundVolume(volumeByAmount);
         } else {
             return null;
         }

--- a/src/main/java/bisq/core/util/CoinUtil.java
+++ b/src/main/java/bisq/core/util/CoinUtil.java
@@ -17,9 +17,12 @@
 
 package bisq.core.util;
 
+import bisq.core.monetary.Volume;
+
 import bisq.common.util.MathUtils;
 
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.utils.Fiat;
 
 public class CoinUtil {
 
@@ -40,5 +43,15 @@ public class CoinUtil {
 
     public static double getFeePerByte(Coin miningFee, int txSize) {
         return MathUtils.roundDouble(((double) miningFee.value / (double) txSize), 2);
+    }
+
+    public static Volume roundVolume(Volume volumeByAmount) {
+        if (volumeByAmount.getMonetary() instanceof Fiat) {
+            final long rounded = MathUtils.roundDoubleToLong(volumeByAmount.getValue() / 10000D) * 10000L;
+            long val = Math.max(10000L, rounded); // We don't allow 0 value
+            return new Volume(Fiat.valueOf(volumeByAmount.getCurrencyCode(), val));
+        } else {
+            return volumeByAmount;
+        }
     }
 }

--- a/src/test/java/bisq/core/util/CoinUtilTest.java
+++ b/src/test/java/bisq/core/util/CoinUtilTest.java
@@ -17,6 +17,8 @@
 
 package bisq.core.util;
 
+import bisq.core.monetary.Volume;
+
 import org.bitcoinj.core.Coin;
 
 import org.slf4j.Logger;
@@ -26,8 +28,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class CoinCryptoUtilsTest {
-    private static final Logger log = LoggerFactory.getLogger(CoinCryptoUtilsTest.class);
+public class CoinUtilTest {
+    private static final Logger log = LoggerFactory.getLogger(CoinUtilTest.class);
 
     @Test
     public void testGetFeePerBtc() {
@@ -53,6 +55,12 @@ public class CoinCryptoUtilsTest {
         assertEquals(Coin.parseCoin("0.1"), CoinUtil.maxCoin(Coin.parseCoin("0.1"), Coin.parseCoin("0.01")));
         assertEquals(Coin.parseCoin("0.05"), CoinUtil.maxCoin(Coin.parseCoin("0"), Coin.parseCoin("0.05")));
         assertEquals(Coin.parseCoin("0.05"), CoinUtil.maxCoin(Coin.parseCoin("0.05"), Coin.parseCoin("0")));
+    }
+
+    @Test
+    public void testRoundFiatVolume() {
+        assertEquals(1000000L, CoinUtil.roundVolume(Volume.parse("100.12", "USD")).getValue());
+        assertEquals(1010000L, CoinUtil.roundVolume(Volume.parse("100.51", "USD")).getValue());
     }
 
 }


### PR DESCRIPTION
- See: https://github.com/bisq-network/bisq-desktop/issues/1511

@ripcurlx Not tested much yet but seems it covers all appearances of volume. Main question is how we avoid confusion of users if the volume amount does not change when the user changes the price.