### PR TITLE
Call init at liteNodeNetworkService at onAllServicesInitialized

### DIFF
--- a/src/main/java/bisq/core/dao/node/lite/LiteNode.java
+++ b/src/main/java/bisq/core/dao/node/lite/LiteNode.java
@@ -81,6 +81,7 @@ public class LiteNode extends BsqNode {
     @Override
     public void onAllServicesInitialized(ErrorMessageHandler errorMessageHandler) {
         super.onInitialized();
+        liteNodeNetworkService.init();
     }
 
     public void shutDown() {

--- a/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
+++ b/src/main/java/bisq/core/dao/node/lite/network/LiteNodeNetworkService.java
@@ -110,15 +110,18 @@ public class LiteNodeNetworkService implements MessageListener, ConnectionListen
         this.peerManager = peerManager;
         // seedNodeAddresses can be empty (in case there is only 1 seed node, the seed node starting up has no other seed nodes)
         this.seedNodeAddresses = new HashSet<>(seedNodesRepository.getSeedNodeAddresses());
-
-        networkNode.addMessageListener(this);
-        networkNode.addConnectionListener(this);
-        peerManager.addListener(this);
     }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void init() {
+        networkNode.addMessageListener(this);
+        networkNode.addConnectionListener(this);
+        peerManager.addListener(this);
+    }
 
     @SuppressWarnings("Duplicates")
     public void shutDown() {


### PR DESCRIPTION
In the current version the LiteNodeNetworkService from the dao package start to requests blocks from seed nodes after all connections lost and re-connection happens. It has not caused problems as the capability check avoided that the msg is sent, but that fix makes sure that the setup of the listeners is not done in the constructor but on init which will not be called if the DAO is not activated.