### PR TITLE
Protobuffer exception handling

### DIFF
--- a/src/main/java/bisq/core/app/SetupUtils.java
+++ b/src/main/java/bisq/core/app/SetupUtils.java
@@ -29,6 +29,7 @@ import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.SealedAndSigned;
 import bisq.common.handlers.ResultHandler;
+import bisq.common.proto.ProtobufferException;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -75,7 +76,7 @@ public class SetupUtils {
                     } else {
                         errorHandler.accept(new CryptoException("Payload not correct after decryption"));
                     }
-                } catch (CryptoException e) {
+                } catch (CryptoException | ProtobufferException e) {
                     log.error(e.toString());
                     e.printStackTrace();
                     errorHandler.accept(e);

--- a/src/main/java/bisq/core/dao/vote/proposal/Proposal.java
+++ b/src/main/java/bisq/core/dao/vote/proposal/Proposal.java
@@ -21,7 +21,7 @@ import bisq.core.dao.vote.proposal.compensation.CompensationRequest;
 import bisq.core.dao.vote.proposal.generic.GenericProposal;
 import bisq.core.dao.vote.result.VoteResult;
 
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistablePayload;
 
 import io.bisq.generated.protobuffer.PB;
@@ -104,7 +104,7 @@ public abstract class Proposal implements PersistablePayload {
             case GENERIC_PROPOSAL:
                 return GenericProposal.fromProto(proto);
             default:
-                throw new ProtobufferException("Unknown message case: " + proto.getMessageCase());
+                throw new ProtobufferRuntimeException("Unknown message case: " + proto.getMessageCase());
         }
     }
 

--- a/src/main/java/bisq/core/dao/vote/proposal/ProposalPayload.java
+++ b/src/main/java/bisq/core/dao/vote/proposal/ProposalPayload.java
@@ -26,7 +26,7 @@ import bisq.network.p2p.storage.payload.ProtectedStoragePayload;
 
 import bisq.common.app.Capabilities;
 import bisq.common.crypto.Sig;
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistablePayload;
 import bisq.common.util.Utilities;
 
@@ -144,7 +144,7 @@ public abstract class ProposalPayload implements LazyProcessedPayload, Protected
             case GENERIC_PROPOSAL_PAYLOAD:
                 return GenericProposalPayload.fromProto(proto);
             default:
-                throw new ProtobufferException("Unknown message case: " + proto.getMessageCase());
+                throw new ProtobufferRuntimeException("Unknown message case: " + proto.getMessageCase());
         }
     }
 

--- a/src/main/java/bisq/core/dao/vote/result/VoteResult.java
+++ b/src/main/java/bisq/core/dao/vote/result/VoteResult.java
@@ -17,7 +17,7 @@
 
 package bisq.core.dao.vote.result;
 
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.network.NetworkPayload;
 import bisq.common.proto.persistable.PersistablePayload;
 
@@ -39,7 +39,7 @@ public abstract class VoteResult implements PersistablePayload, NetworkPayload {
             case LONG_VOTE_RESULT:
                 return LongVoteResult.fromProto(proto);
             default:
-                throw new ProtobufferException("Unknown message case: " + proto.getMessageCase());
+                throw new ProtobufferRuntimeException("Unknown message case: " + proto.getMessageCase());
         }
     }
 

--- a/src/main/java/bisq/core/locale/TradeCurrency.java
+++ b/src/main/java/bisq/core/locale/TradeCurrency.java
@@ -17,7 +17,7 @@
 
 package bisq.core.locale;
 
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistablePayload;
 
 import io.bisq.generated.protobuffer.PB;
@@ -53,7 +53,7 @@ public abstract class TradeCurrency implements PersistablePayload, Comparable<Tr
             case CRYPTO_CURRENCY:
                 return CryptoCurrency.fromProto(proto);
             default:
-                throw new ProtobufferException("Unknown message case: " + proto.getMessageCase());
+                throw new ProtobufferRuntimeException("Unknown message case: " + proto.getMessageCase());
         }
     }
 

--- a/src/main/java/bisq/core/proto/CoreProtoResolver.java
+++ b/src/main/java/bisq/core/proto/CoreProtoResolver.java
@@ -46,7 +46,7 @@ import bisq.core.payment.payload.WesternUnionAccountPayload;
 import bisq.core.trade.statistics.TradeStatistics2;
 
 import bisq.common.proto.ProtoResolver;
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistableEnvelope;
 
 import io.bisq.generated.protobuffer.PB;
@@ -81,7 +81,7 @@ public class CoreProtoResolver implements ProtoResolver {
                                 case SPECIFIC_BANKS_ACCOUNT_PAYLOAD:
                                     return SpecificBanksAccountPayload.fromProto(proto);
                                 default:
-                                    throw new ProtobufferException("Unknown proto message case" +
+                                    throw new ProtobufferRuntimeException("Unknown proto message case" +
                                             "(PB.PaymentAccountPayload.CountryBasedPaymentAccountPayload.BankAccountPayload). " +
                                             "messageCase=" + messageCaseBank);
                             }
@@ -94,7 +94,7 @@ public class CoreProtoResolver implements ProtoResolver {
                         case SEPA_INSTANT_ACCOUNT_PAYLOAD:
                             return SepaInstantAccountPayload.fromProto(proto);
                         default:
-                            throw new ProtobufferException("Unknown proto message case" +
+                            throw new ProtobufferRuntimeException("Unknown proto message case" +
                                     "(PB.PaymentAccountPayload.CountryBasedPaymentAccountPayload)." +
                                     " messageCase=" + messageCaseCountry);
                     }
@@ -125,11 +125,11 @@ public class CoreProtoResolver implements ProtoResolver {
                 case U_S_POSTAL_MONEY_ORDER_ACCOUNT_PAYLOAD:
                     return USPostalMoneyOrderAccountPayload.fromProto(proto);
                 default:
-                    throw new ProtobufferException("Unknown proto message case(PB.PaymentAccountPayload). messageCase=" + messageCase);
+                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.PaymentAccountPayload). messageCase=" + messageCase);
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.PaymentAccountPayload is null");
-            throw new ProtobufferException("PB.PaymentAccountPayload is null");
+            throw new ProtobufferRuntimeException("PB.PaymentAccountPayload is null");
         }
     }
 
@@ -142,11 +142,11 @@ public class CoreProtoResolver implements ProtoResolver {
                 case TRADE_STATISTICS2:
                     return TradeStatistics2.fromProto(proto.getTradeStatistics2());
                 default:
-                    throw new ProtobufferException("Unknown proto message case (PB.PersistableNetworkPayload). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case (PB.PersistableNetworkPayload). messageCase=" + proto.getMessageCase());
             }
         } else {
             log.error("PB.PersistableNetworkPayload is null");
-            throw new ProtobufferException("PB.PersistableNetworkPayload is null");
+            throw new ProtobufferRuntimeException("PB.PersistableNetworkPayload is null");
         }
     }
 }

--- a/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -61,7 +61,7 @@ import bisq.network.p2p.storage.payload.MailboxStoragePayload;
 import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkPayload;
 import bisq.common.proto.network.NetworkProtoResolver;
@@ -154,11 +154,11 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case ADD_PERSISTABLE_NETWORK_PAYLOAD_MESSAGE:
                     return AddPersistableNetworkPayloadMessage.fromProto(proto.getAddPersistableNetworkPayloadMessage(), this, messageVersion);
                 default:
-                    throw new ProtobufferException("Unknown proto message case (PB.NetworkEnvelope). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case (PB.NetworkEnvelope). messageCase=" + proto.getMessageCase());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.NetworkEnvelope is null");
-            throw new ProtobufferException("PB.NetworkEnvelope is null");
+            throw new ProtobufferRuntimeException("PB.NetworkEnvelope is null");
         }
     }
 
@@ -170,11 +170,11 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case PROTECTED_STORAGE_ENTRY:
                     return ProtectedStorageEntry.fromProto(proto.getProtectedStorageEntry(), this);
                 default:
-                    throw new ProtobufferException("Unknown proto message case(PB.StorageEntryWrapper). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.StorageEntryWrapper). messageCase=" + proto.getMessageCase());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.StorageEntryWrapper is null");
-            throw new ProtobufferException("PB.StorageEntryWrapper is null");
+            throw new ProtobufferRuntimeException("PB.StorageEntryWrapper is null");
         }
     }
 
@@ -201,11 +201,11 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case BLIND_VOTE:
                     return BlindVote.fromProto(proto.getBlindVote());
                 default:
-                    throw new ProtobufferException("Unknown proto message case (PB.StoragePayload). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case (PB.StoragePayload). messageCase=" + proto.getMessageCase());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.StoragePayload is null");
-            throw new ProtobufferException("PB.StoragePayload is null");
+            throw new ProtobufferRuntimeException("PB.StoragePayload is null");
         }
     }
 }

--- a/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -61,6 +61,7 @@ import bisq.network.p2p.storage.payload.MailboxStoragePayload;
 import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 
+import bisq.common.proto.ProtobufferException;
 import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.network.NetworkEnvelope;
 import bisq.common.proto.network.NetworkPayload;
@@ -72,6 +73,7 @@ import javax.inject.Inject;
 
 import lombok.extern.slf4j.Slf4j;
 
+// TODO Use ProtobufferException instead of ProtobufferRuntimeException
 @Slf4j
 public class CoreNetworkProtoResolver extends CoreProtoResolver implements NetworkProtoResolver {
 
@@ -80,7 +82,7 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
     }
 
     @Override
-    public NetworkEnvelope fromProto(PB.NetworkEnvelope proto) {
+    public NetworkEnvelope fromProto(PB.NetworkEnvelope proto) throws ProtobufferException {
         if (proto != null) {
             final int messageVersion = proto.getMessageVersion();
             switch (proto.getMessageCase()) {
@@ -154,11 +156,12 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case ADD_PERSISTABLE_NETWORK_PAYLOAD_MESSAGE:
                     return AddPersistableNetworkPayloadMessage.fromProto(proto.getAddPersistableNetworkPayloadMessage(), this, messageVersion);
                 default:
-                    throw new ProtobufferRuntimeException("Unknown proto message case (PB.NetworkEnvelope). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferException("Unknown proto message case (PB.NetworkEnvelope). messageCase=" +
+                            proto.getMessageCase() + "; proto raw data=" + proto.toString());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.NetworkEnvelope is null");
-            throw new ProtobufferRuntimeException("PB.NetworkEnvelope is null");
+            throw new ProtobufferException("PB.NetworkEnvelope is null");
         }
     }
 
@@ -170,7 +173,8 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case PROTECTED_STORAGE_ENTRY:
                     return ProtectedStorageEntry.fromProto(proto.getProtectedStorageEntry(), this);
                 default:
-                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.StorageEntryWrapper). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.StorageEntryWrapper). " +
+                            "messageCase=" + proto.getMessageCase() + "; proto raw data=" + proto.toString());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.StorageEntryWrapper is null");
@@ -201,7 +205,8 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
                 case BLIND_VOTE:
                     return BlindVote.fromProto(proto.getBlindVote());
                 default:
-                    throw new ProtobufferRuntimeException("Unknown proto message case (PB.StoragePayload). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case (PB.StoragePayload). messageCase="
+                            + proto.getMessageCase() + "; proto raw data=" + proto.toString());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.StoragePayload is null");

--- a/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
+++ b/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
@@ -54,6 +54,7 @@ import java.io.File;
 
 import lombok.extern.slf4j.Slf4j;
 
+// TODO Use ProtobufferException instead of ProtobufferRuntimeException
 @Slf4j
 public class CorePersistenceProtoResolver extends CoreProtoResolver implements PersistenceProtoResolver {
     private final Provider<BtcWalletService> btcWalletService;
@@ -116,7 +117,8 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                     return ParamChangeEventList.fromProto(proto.getParamChangeEventList());
 
                 default:
-                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.PersistableEnvelope). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.PersistableEnvelope). " +
+                            "messageCase=" + proto.getMessageCase() + "; proto raw data=" + proto.toString());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.PersistableEnvelope is null");

--- a/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
+++ b/src/main/java/bisq/core/proto/persistable/CorePersistenceProtoResolver.java
@@ -36,7 +36,7 @@ import bisq.network.p2p.storage.PersistableNetworkPayloadList;
 import bisq.network.p2p.storage.PersistedEntryMap;
 import bisq.network.p2p.storage.SequenceNumberMap;
 
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.network.NetworkProtoResolver;
 import bisq.common.proto.persistable.NavigationPath;
 import bisq.common.proto.persistable.PersistableEnvelope;
@@ -89,7 +89,7 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                             new Storage<>(storageDir, this),
                             btcWalletService.get());
                 case TRADE_STATISTICS_LIST:
-                    throw new ProtobufferException("TRADE_STATISTICS_LIST is not used anymore");
+                    throw new ProtobufferRuntimeException("TRADE_STATISTICS_LIST is not used anymore");
                 case DISPUTE_LIST:
                     return DisputeList.fromProto(proto.getDisputeList(),
                             this,
@@ -116,11 +116,11 @@ public class CorePersistenceProtoResolver extends CoreProtoResolver implements P
                     return ParamChangeEventList.fromProto(proto.getParamChangeEventList());
 
                 default:
-                    throw new ProtobufferException("Unknown proto message case(PB.PersistableEnvelope). messageCase=" + proto.getMessageCase());
+                    throw new ProtobufferRuntimeException("Unknown proto message case(PB.PersistableEnvelope). messageCase=" + proto.getMessageCase());
             }
         } else {
             log.error("PersistableEnvelope.fromProto: PB.PersistableEnvelope is null");
-            throw new ProtobufferException("PB.PersistableEnvelope is null");
+            throw new ProtobufferRuntimeException("PB.PersistableEnvelope is null");
         }
     }
 }

--- a/src/main/java/bisq/core/trade/TradableList.java
+++ b/src/main/java/bisq/core/trade/TradableList.java
@@ -22,7 +22,7 @@ import bisq.core.offer.OpenOffer;
 import bisq.core.proto.CoreProtoResolver;
 
 import bisq.common.proto.ProtoUtil;
-import bisq.common.proto.ProtobufferException;
+import bisq.common.proto.ProtobufferRuntimeException;
 import bisq.common.proto.persistable.PersistableEnvelope;
 import bisq.common.storage.Storage;
 
@@ -104,7 +104,7 @@ public final class TradableList<T extends Tradable> implements PersistableEnvelo
                             return SellerAsTakerTrade.fromProto(tradable.getSellerAsTakerTrade(), storage, btcWalletService, coreProtoResolver);
                         default:
                             log.error("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
-                            throw new ProtobufferException("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
+                            throw new ProtobufferRuntimeException("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
                     }
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
https://github.com/bisq-network/bisq-common/pull/25 and https://github.com/bisq-network/bisq-p2p/pull/11
- Use ProtobufferException for
CoreNetworkProtoResolver.fromProto(PB.NetworkEnvelope proto)
- Add raw PB data in case if an exception
- log error if the encrypted data contains unknown PB data

Note: We should refactor the resolvers with checked exceptions instead
of the ProtobufferRuntimeException, but for the moment we leave that to
not add too much complexity/risk for that release.