### PR TITLE
Misc fixes and cleanups

### DIFF
--- a/src/main/java/bisq/core/app/AppOptionKeys.java
+++ b/src/main/java/bisq/core/app/AppOptionKeys.java
@@ -26,4 +26,5 @@ public class AppOptionKeys {
     public static final String DUMP_STATISTICS = "dumpStatistics";
     public static final String IGNORE_DEV_MSG_KEY = "ignoreDevMsg";
     public static final String USE_DEV_PRIVILEGE_KEYS = "useDevPrivilegeKeys";
+    public static final String REFERRAL_ID = "referralId";
 }

--- a/src/main/java/bisq/core/app/BisqEnvironment.java
+++ b/src/main/java/bisq/core/app/BisqEnvironment.java
@@ -195,7 +195,7 @@ public class BisqEnvironment extends StandardEnvironment {
     protected final String btcNodes, seedNodes, ignoreDevMsg, useDevPrivilegeKeys, useDevMode, useTorForBtc, rpcUser, rpcPassword,
             rpcPort, rpcBlockNotificationPort, dumpBlockchainData, fullDaoNode,
             myAddress, banList, dumpStatistics, maxMemory, socks5ProxyBtcAddress,
-            socks5ProxyHttpAddress, useAllProvidedNodes, numConnectionForBtc, genesisTxId, genesisBlockHeight;
+            socks5ProxyHttpAddress, useAllProvidedNodes, numConnectionForBtc, genesisTxId, genesisBlockHeight, referralId;
 
 
     public BisqEnvironment(OptionSet options) {
@@ -229,6 +229,9 @@ public class BisqEnvironment extends StandardEnvironment {
                 "";
         useDevPrivilegeKeys = commandLineProperties.containsProperty(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS) ?
                 (String) commandLineProperties.getProperty(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS) :
+                "";
+        referralId = commandLineProperties.containsProperty(AppOptionKeys.REFERRAL_ID) ?
+                (String) commandLineProperties.getProperty(AppOptionKeys.REFERRAL_ID) :
                 "";
         useDevMode = commandLineProperties.containsProperty(CommonOptionKeys.USE_DEV_MODE) ?
                 (String) commandLineProperties.getProperty(CommonOptionKeys.USE_DEV_MODE) :
@@ -428,6 +431,7 @@ public class BisqEnvironment extends StandardEnvironment {
                 setProperty(AppOptionKeys.APP_DATA_DIR_KEY, appDataDir);
                 setProperty(AppOptionKeys.IGNORE_DEV_MSG_KEY, ignoreDevMsg);
                 setProperty(AppOptionKeys.USE_DEV_PRIVILEGE_KEYS, useDevPrivilegeKeys);
+                setProperty(AppOptionKeys.REFERRAL_ID, referralId);
                 setProperty(CommonOptionKeys.USE_DEV_MODE, useDevMode);
                 setProperty(AppOptionKeys.DUMP_STATISTICS, dumpStatistics);
                 setProperty(AppOptionKeys.APP_NAME_KEY, appName);

--- a/src/main/java/bisq/core/app/BisqExecutable.java
+++ b/src/main/java/bisq/core/app/BisqExecutable.java
@@ -322,6 +322,9 @@ public abstract class BisqExecutable implements GracefulShutDownHandler {
                         "(This is for developers only!)", false))
                 .withRequiredArg()
                 .ofType(boolean.class);
+        parser.accepts(AppOptionKeys.REFERRAL_ID,
+                description("Optional Referral ID (e.g. for API users or pro market makers)", ""))
+                .withRequiredArg();
         parser.accepts(CommonOptionKeys.USE_DEV_MODE,
                 description("Enables dev mode which is used for convenience for developer testing", false))
                 .withRequiredArg()

--- a/src/main/java/bisq/core/app/CoreModule.java
+++ b/src/main/java/bisq/core/app/CoreModule.java
@@ -96,6 +96,8 @@ public class CoreModule extends AppModule {
         Boolean useDevMode = environment.getProperty(CommonOptionKeys.USE_DEV_MODE, Boolean.class, false);
         bind(boolean.class).annotatedWith(Names.named(CommonOptionKeys.USE_DEV_MODE)).toInstance(useDevMode);
 
+        bindConstant().annotatedWith(named(AppOptionKeys.REFERRAL_ID)).to(environment.getRequiredProperty(AppOptionKeys.REFERRAL_ID));
+
         // ordering is used for shut down sequence
         install(tradeModule());
         install(encryptionServiceModule());

--- a/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -551,7 +551,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             if (openOfferOptional.isPresent()) {
                 if (openOfferOptional.get().getState() == OpenOffer.State.AVAILABLE) {
                     final Offer offer = openOfferOptional.get().getOffer();
-                    if (preferences.getIgnoreTradersList().stream().noneMatch(hostName -> hostName.equals(offer.getMakerNodeAddress().getHostNameWithoutPostFix()))) {
+                    if (preferences.getIgnoreTradersList().stream().noneMatch(hostName -> hostName.equals(peer.getHostNameWithoutPostFix()))) {
                         availabilityResult = AvailabilityResult.AVAILABLE;
 
                         List<NodeAddress> acceptedArbitrators = user.getAcceptedArbitratorAddresses();

--- a/src/main/java/bisq/core/provider/price/PriceFeedService.java
+++ b/src/main/java/bisq/core/provider/price/PriceFeedService.java
@@ -51,10 +51,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -302,7 +302,7 @@ public class PriceFeedService {
             return new Date();
     }
 
-    public void applyLatestBisqMarketPrice(HashSet<TradeStatistics2> tradeStatisticsSet) {
+    public void applyLatestBisqMarketPrice(Set<TradeStatistics2> tradeStatisticsSet) {
         // takes about 10 ms for 5000 items
         Map<String, List<TradeStatistics2>> mapByCurrencyCode = new HashMap<>();
         tradeStatisticsSet.forEach(e -> {

--- a/src/main/java/bisq/core/user/Preferences.java
+++ b/src/main/java/bisq/core/user/Preferences.java
@@ -17,6 +17,7 @@
 
 package bisq.core.user;
 
+import bisq.core.app.AppOptionKeys;
 import bisq.core.app.BisqEnvironment;
 import bisq.core.btc.BaseCurrencyNetwork;
 import bisq.core.btc.BitcoinNodes;
@@ -140,6 +141,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     private final BisqEnvironment bisqEnvironment;
     private final String btcNodesFromOptions;
     private final String useTorFlagFromOptions;
+    private final String referralIdFromOptions;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -152,12 +154,14 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     public Preferences(Storage<PreferencesPayload> storage,
                        BisqEnvironment bisqEnvironment,
                        @Named(BtcOptionKeys.BTC_NODES) String btcNodesFromOptions,
-                       @Named(BtcOptionKeys.USE_TOR_FOR_BTC) String useTorFlagFromOptions) {
+                       @Named(BtcOptionKeys.USE_TOR_FOR_BTC) String useTorFlagFromOptions,
+                       @Named(AppOptionKeys.REFERRAL_ID) String referralId) {
 
         this.storage = storage;
         this.bisqEnvironment = bisqEnvironment;
         this.btcNodesFromOptions = btcNodesFromOptions;
         this.useTorFlagFromOptions = useTorFlagFromOptions;
+        this.referralIdFromOptions = referralId;
 
         useAnimationsProperty.addListener((ov) -> {
             prefPayload.setUseAnimations(useAnimationsProperty.get());
@@ -272,6 +276,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
             setBitcoinNodes(btcNodesFromOptions);
             setBitcoinNodesOptionOrdinal(BitcoinNodes.BitcoinNodesOption.CUSTOM.ordinal());
         }
+        if (referralIdFromOptions != null && !referralIdFromOptions.isEmpty())
+            setReferralId(referralIdFromOptions);
 
         initialReadDone = true;
         persist();

--- a/src/main/resources/i18n/displayStrings.properties
+++ b/src/main/resources/i18n/displayStrings.properties
@@ -516,7 +516,7 @@ portfolio.pending.step2_buyer.altcoin=Please transfer from your external {0} wal
 portfolio.pending.step2_buyer.cash=Please go to a bank and pay {0} to the BTC seller.\n\n
 portfolio.pending.step2_buyer.cash.extra=IMPORTANT REQUIREMENT:\nAfter you have done the payment write on the paper receipt: NO REFUNDS.\nThen tear it in 2 parts, make a photo and send it to the BTC seller's email address.
 portfolio.pending.step2_buyer.moneyGram=Please pay {0} to the BTC seller by using MoneyGram.\n\n
-portfolio.pending.step2_buyer.moneyGram.extra=IMPORTANT REQUIREMENT:\nAfter you have done the payment send the Authorisation # and a photo of the receipt by email to the BTC seller.\n\
+portfolio.pending.step2_buyer.moneyGram.extra=IMPORTANT REQUIREMENT:\nAfter you have done the payment send the Authorisation number and a photo of the receipt by email to the BTC seller.\n\
   The receipt must clearly show the seller''s full name, country, state and the amount. The seller''s email is: {0}.
 portfolio.pending.step2_buyer.westernUnion=Please pay {0} to the BTC seller by using Western Union.\n\n
 portfolio.pending.step2_buyer.westernUnion.extra=IMPORTANT REQUIREMENT:\nAfter you have done the payment send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller.\n\
@@ -536,10 +536,10 @@ portfolio.pending.step2_buyer.paperReceipt.headline=Did you send the paper recei
 portfolio.pending.step2_buyer.paperReceipt.msg=Remember:\n\
   You need to write on the paper receipt: NO REFUNDS.\n\
   Then tear it in 2 parts, make a photo and send it to the BTC seller's email address.
-portfolio.pending.step2_buyer.moneyGramMTCNInfo.headline=Send Authorisation # and receipt
-portfolio.pending.step2_buyer.moneyGramMTCNInfo.msg=You need to send the Authorisation # and a photo of the receipt by email to the BTC seller.\n\
+portfolio.pending.step2_buyer.moneyGramMTCNInfo.headline=Send Authorisation number and receipt
+portfolio.pending.step2_buyer.moneyGramMTCNInfo.msg=You need to send the Authorisation number and a photo of the receipt by email to the BTC seller.\n\
   The receipt must clearly show the seller''s full name, country, state and the amount. The seller''s email is: {0}.\n\n\
-  Did you send the Authorisation # and contract to the seller?
+  Did you send the Authorisation number and contract to the seller?
 portfolio.pending.step2_buyer.westernUnionMTCNInfo.headline=Send MTCN and receipt
 portfolio.pending.step2_buyer.westernUnionMTCNInfo.msg=You need to send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller.\n\
   The receipt must clearly show the seller''s full name, city, country and the amount. The seller''s email is: {0}.\n\n\
@@ -582,8 +582,8 @@ The trade ID (\"reason for payment\" text) of the transaction is: \"{2}\"\n\n
 portfolio.pending.step3_seller.cash=\n\nBecause the payment is done via Cash Deposit the BTC buyer has to write \"NO REFUND\" on the paper receipt, tear it in 2 parts and send you a photo by email.\n\n\
 To avoid chargeback risk, only confirm if you received the email and if you are sure the paper receipt is valid.\n\
 If you are not sure, {0}
-portfolio.pending.step3_seller.moneyGram=The buyer has to send you the Authorisation # and a photo of the receipt by email.\n\
-  The receipt must clearly show your full name, country, state and the amount. Please check your email if you received the Authorisation #.\n\n\
+portfolio.pending.step3_seller.moneyGram=The buyer has to send you the Authorisation number and a photo of the receipt by email.\n\
+  The receipt must clearly show your full name, country, state and the amount. Please check your email if you received the Authorisation number.\n\n\
   After closing that popup you will see the BTC buyer's name and address for picking up the money from MoneyGram.\n\n\
   Only confirm receipt after you have successfully picked up the money!
 portfolio.pending.step3_seller.westernUnion=The buyer has to send you the MTCN (tracking number) and a photo of the receipt by email.\n\
@@ -642,8 +642,8 @@ portfolio.pending.step5_seller.received=You have received:
 tradeFeedbackWindow.title=Congratulations on completing your trade
 tradeFeedbackWindow.msg.part1=We'd love to hear back from you about your experience. It'll help us to improve the software \
   and to smooth out any rough edges. If you'd like to provide feedback, please fill out this one-minute survey \
-  (no registration required) at https://bisq.network/survey.
-tradeFeedbackWindow.msg.part2=If you have any questions, or experienced any problems, please get in touch with other users and contributors via the Bisq forum at https://bisq.community.
+  (no registration required) at:
+tradeFeedbackWindow.msg.part2=If you have any questions, or experienced any problems, please get in touch with other users and contributors via the Bisq forum at:
 tradeFeedbackWindow.msg.part3=Thanks for using Bisq!
 
 portfolio.pending.role=My role
@@ -1814,7 +1814,7 @@ If you have not fulfilled the above requirements you will lose your security dep
 to get in contact with the {1} buyer by using the provided email address or mobile number to verify that he or she \
   is really the owner of the Zelle (ClearXchange) account.
 
-payment.moneyGram.info=When using MoneyGram the BTC buyer has to send the Authorisation # and a photo of the receipt by email to the BTC seller. \
+payment.moneyGram.info=When using MoneyGram the BTC buyer has to send the Authorisation number and a photo of the receipt by email to the BTC seller. \
   The receipt must clearly show the seller's full name, country, state and the amount. The buyer will get displayed the seller's email in the trade process.
 payment.westernUnion.info=When using Western Union the BTC buyer has to send the MTCN (tracking number) and a photo of the receipt by email to the BTC seller. \
   The receipt must clearly show the seller's full name, city, country and the amount. The buyer will get displayed the seller's email in the trade process.

--- a/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/src/test/java/bisq/core/user/PreferencesTest.java
@@ -67,7 +67,7 @@ public class PreferencesTest {
         storage = mock(Storage.class);
         bisqEnvironment = mock(BisqEnvironment.class);
 
-        preferences = new Preferences(storage, bisqEnvironment,null, null);
+        preferences = new Preferences(storage, bisqEnvironment, null, null, null);
     }
 
     @Test


### PR DESCRIPTION
- Fix bug with ignored taker check (use peer instead of
offer.getMakerNodeAddress()).
- Remove redundant tradeStatisticsSet in TradeStatisticsManager
- Remove handling for old TradeStatistics objects (since v 0.6.0 not
supported anymore)
- Use marketPricePresentation.priceFeedComboBoxItems instead of
- MainVievModel.priceFeedComboBoxItems.
- Replace Authorisation # with Authorisation number.
- Remove https://bisq.network/survey and https://bisq.community links
in tradeFeedbackWindow text.
- Add null checks.
- Improve logging.
- Cleanup