### PR TITLE
Refine trade feedback message

### DIFF
--- a/src/main/resources/i18n/displayStrings.properties
+++ b/src/main/resources/i18n/displayStrings.properties
@@ -641,7 +641,7 @@ portfolio.pending.step5_seller.received=You have received:
 
 tradeFeedbackWindow.title=Congratulations on completing your trade
 tradeFeedbackWindow.msg.part1=We'd love to hear back from you about your experience. It'll help us to improve the software \
-  and to smooth out any rough edges. If you'd like to provide feedback, please fill out this one-minute survey \
+  and to smooth out any rough edges. If you'd like to provide feedback, please fill out this short survey \
   (no registration required) at:
 tradeFeedbackWindow.msg.part2=If you have any questions, or experienced any problems, please get in touch with other users and contributors via the Bisq forum at:
 tradeFeedbackWindow.msg.part3=Thanks for using Bisq!


### PR DESCRIPTION
Previously the message specified that the survey was "one minute" in
duration. This was based on my reading on the statistic on the survey
itself of how long the average user had been taking to fill out the
survey. I realize now that this is not necessarily an accurate
representation of how long it would take to actually fill out the full
form, but rather how long people had been taking before clicking submit.

Now, it simply says that it is a 'short' survey without specifying any
particular duration.