### PR TITLE
List Conceal (CCX)

### DIFF
--- a/src/main/resources/i18n/displayStrings.properties
+++ b/src/main/resources/i18n/displayStrings.properties
@@ -988,6 +988,15 @@ dispute case. The XMR sender is responsible to be able to verify the XMR transfe
 arbitrator in case of a dispute.\n\n\
 There is no payment ID required, just the normal public address.\n\n\
 If you are not sure about that process visit the Monero forum (https://forum.getmonero.org) to find more information.
+account.altcoin.popup.ccx.msg=If you want to trade CCX on Bisq please be sure you understand the following requirements:\n\n\
+To send CCX you must use the Conceal CLI wallet (concealwallet). After sending a transfer payment, the wallet\n\
+displays the transaction hash (ID) and secret key. You must save both in case arbitration is necessary.\n\
+In that case, you must give them to the arbitrator along with the recipient's public address, who will then\n\
+verify the CCX transfer using the Conceal Transaction Viewer (https://explorer.conceal.network/txviewer).\n\
+Because Conceal is a privacy coin, block explorers cannot verify transfers.\n\n\
+If you cannot provide the required data to the arbitrator, you will lose the dispute case.\n\
+If you do not save the transaction secret key immediately after transferring CCX, it cannot be recovered later.\n\
+If you do not understand these requirements, seek help at the Conceal discord (http://discord.conceal.network).
 account.altcoin.popup.ZEC.msg=When using {0} you can only use the transparent addresses (starting with t) not \
 the z-addresses (private), because the arbitrator would not be able to verify the transaction with z-addresses.
 account.altcoin.popup.XZC.msg=When using {0} you can only use the transparent (traceable) addresses not \


### PR DESCRIPTION
Official project URL: https://conceal.network/
Official block explorer URL: https://explorer.conceal.network/
Additional: The Conceal CLI simple wallet provides a secret transaction key that enables 3rd party audits in case of a dispute similar to Monero. We are submitting separate pull requests for a pop-up explaining CCX trading requirements on Bisq.