### PR TITLE
List Blur (BLUR)

### DIFF
--- a/src/main/resources/i18n/displayStrings.properties
+++ b/src/main/resources/i18n/displayStrings.properties
@@ -988,6 +988,16 @@ dispute case. The XMR sender is responsible to be able to verify the XMR transfe
 arbitrator in case of a dispute.\n\n\
 There is no payment ID required, just the normal public address.\n\n\
 If you are not sure about that process visit the Monero forum (https://forum.getmonero.org) to find more information.
+account.altcoin.popup.blur.msg=If you want to trade BLUR on Bisq please be sure you understand and fulfill \
+the following requirements:\n\n\
+To send BLUR you must use the Blur Network CLI wallet (blur-wallet-cli). After sending a transfer payment, the\n\
+wallet displays a transaction hash (tx ID). You must save this information. You must also use the 'get_tx_key'\n\
+command to retrieve the transaction private key. In the event that arbitration is necessary, you must present\n\
+both the transaction ID and the transaction private key, along with the recipient's public address.  The arbitrator\n\
+will then verify the BLUR transfer using the Blur Transaction Viewer (https://blur.cash/#tx-viewer).\n\n\
+If you cannot provide the required data to the arbitrator, you will lose the dispute case.\n\
+The BLUR sender is responsible for the ability to verify BLUR transfers to the arbitrator in case of a dispute.\n\n\
+If you do not understand these requirements, seek help at the Blur Network Discord (https://discord.gg/5rwkU2g).
 account.altcoin.popup.ccx.msg=If you want to trade CCX on Bisq please be sure you understand the following requirements:\n\n\
 To send CCX you must use the Conceal CLI wallet (concealwallet). After sending a transfer payment, the wallet\n\
 displays the transaction hash (ID) and secret key. You must save both in case arbitration is necessary.\n\


### PR DESCRIPTION
Official project URL: https://blur.cash
Official block explorer URL: http://explorer.blur.cash
Additional: The Blur CLI wallet issues a transaction private key, similar to Monero. Using that key and a recipient address, arbitrators can verify transactions by using the Blur Transaction Viewer (https://blur.cash/#tx-viewer). Two additional pull requests are being submitted for a pop-up explaining the requirements for trading BLUR on Bisq.

The two other PR's can be found here:
bisq-network/bisq-assets#58
bisq-network/bisq-desktop#1617