### PR TITLE
Update CCX popup to mention our GUI wallet.

### DIFF
--- a/src/main/resources/i18n/displayStrings.properties
+++ b/src/main/resources/i18n/displayStrings.properties
@@ -999,9 +999,9 @@ If you cannot provide the required data to the arbitrator, you will lose the dis
 The BLUR sender is responsible for the ability to verify BLUR transfers to the arbitrator in case of a dispute.\n\n\
 If you do not understand these requirements, seek help at the Blur Network Discord (https://discord.gg/5rwkU2g).
 account.altcoin.popup.ccx.msg=If you want to trade CCX on Bisq please be sure you understand the following requirements:\n\n\
-To send CCX you must use the Conceal CLI wallet (concealwallet). After sending a transfer payment, the wallet\n\
-displays the transaction hash (ID) and secret key. You must save both in case arbitration is necessary.\n\
-In that case, you must give them to the arbitrator along with the recipient's public address, who will then\n\
+To send CCX you must use an official Conceal wallet, either CLI or GUI. After sending a transfer payment, the wallets\n\
+display the transaction secret key. You must save it along with the transaction hash (ID) and the recipient's public\n\
+address in case arbitration is necessary. In such a case, you must give all three to the arbitrator, who will then\n\
 verify the CCX transfer using the Conceal Transaction Viewer (https://explorer.conceal.network/txviewer).\n\
 Because Conceal is a privacy coin, block explorers cannot verify transfers.\n\n\
 If you cannot provide the required data to the arbitrator, you will lose the dispute case.\n\


### PR DESCRIPTION
Please accept this small edit to the CCX popup. The existing popup requires users to use our simple wallet (CLI). Now users can also use our GUI wallet, which will be easier for most users. Thank you.