### PR TITLE
Make TxInputParser.process() take TxOutputKey instead of TxInput 

### DIFF
--- a/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -60,10 +60,9 @@ public class BlockParser {
                        BsqStateService bsqStateService) {
         this.txParser = txParser;
         this.bsqStateService = bsqStateService;
-
-        genesisTxId = bsqStateService.getGenesisTxId();
-        genesisBlockHeight = bsqStateService.getGenesisBlockHeight();
-        genesisTotalSupply = bsqStateService.getGenesisTotalSupply();
+        this.genesisTxId = bsqStateService.getGenesisTxId();
+        this.genesisBlockHeight = bsqStateService.getGenesisBlockHeight();
+        this.genesisTotalSupply = bsqStateService.getGenesisTotalSupply();
     }
 
 

--- a/src/main/java/bisq/core/dao/node/parser/TxInputParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxInputParser.java
@@ -21,6 +21,7 @@ import bisq.core.dao.state.BsqStateService;
 import bisq.core.dao.state.blockchain.SpentInfo;
 import bisq.core.dao.state.blockchain.TxInput;
 import bisq.core.dao.state.blockchain.TxOutput;
+import bisq.core.dao.state.blockchain.TxOutputKey;
 import bisq.core.dao.state.blockchain.TxOutputType;
 
 import javax.inject.Inject;
@@ -43,8 +44,8 @@ public class TxInputParser {
     }
 
     @SuppressWarnings("IfCanBeSwitch")
-    void process(TxInput txInput, int blockHeight, String txId, int inputIndex, ParsingModel parsingModel) {
-        bsqStateService.getUnspentTxOutput(txInput.getConnectedTxOutputKey())
+    void process(TxOutputKey txOutputKey, int blockHeight, String txId, int inputIndex, ParsingModel parsingModel) {
+        bsqStateService.getUnspentTxOutput(txOutputKey)
                 .ifPresent(connectedTxOutput -> {
                     parsingModel.addToInputValue(connectedTxOutput.getValue());
 

--- a/src/main/java/bisq/core/dao/node/parser/TxParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxParser.java
@@ -24,6 +24,7 @@ import bisq.core.dao.state.blockchain.TempTx;
 import bisq.core.dao.state.blockchain.TempTxOutput;
 import bisq.core.dao.state.blockchain.Tx;
 import bisq.core.dao.state.blockchain.TxInput;
+import bisq.core.dao.state.blockchain.TxOutputKey;
 import bisq.core.dao.state.blockchain.TxOutputType;
 import bisq.core.dao.state.blockchain.TxType;
 
@@ -86,7 +87,8 @@ public class TxParser {
 
         for (int inputIndex = 0; inputIndex < tempTx.getTxInputs().size(); inputIndex++) {
             TxInput input = tempTx.getTxInputs().get(inputIndex);
-            txInputParser.process(input, blockHeight, tempTx.getId(), inputIndex, parsingModel);
+            TxOutputKey outputKey = input.getConnectedTxOutputKey();
+            txInputParser.process(outputKey, blockHeight, rawTx.getId(), inputIndex, parsingModel);
         }
 
         final boolean leftOverBsq = parsingModel.isInputValuePositive();


### PR DESCRIPTION
Also use this.foo consistently in BlockParser constructor.