### PR TITLE
Parse opreturn before other outputs

### DIFF
--- a/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -47,6 +47,7 @@ public class TxOutputParser {
     @Getter
     @Setter
     private long availableInputValue = 0;
+    private int lockTime;
     @Setter
     private int unlockBlockHeight;
     @Setter
@@ -81,8 +82,9 @@ public class TxOutputParser {
         }
     }
 
-    void processOpReturnCandidate(TempTxOutput txOutput) {
+    boolean processOpReturnCandidate(TempTxOutput txOutput) {
         optionalOpReturnTypeCandidate = OpReturnParser.getOptionalOpReturnTypeCandidate(txOutput);
+        return optionalOpReturnTypeCandidate.isPresent();
     }
 
     /**
@@ -164,6 +166,7 @@ public class TxOutputParser {
             optionalVoteRevealUnlockStakeOutput = Optional.of(txOutput);
         } else if (isFirstOutput && opReturnTypeCandidate == OpReturnType.LOCKUP) {
             bsqOutput = TxOutputType.LOCKUP;
+            txOutput.setLockTime(lockTime);
             optionalLockupOutput = Optional.of(txOutput);
         } else {
             bsqOutput = TxOutputType.BSQ_OUTPUT;
@@ -199,8 +202,7 @@ public class TxOutputParser {
                 .ifPresent(verifiedOpReturnType -> {
                     byte[] opReturnData = tempTxOutput.getOpReturnData();
                     checkNotNull(opReturnData, "opReturnData must not be null");
-                    int lockTime = BondingConsensus.getLockTime(opReturnData);
-                    tempTxOutput.setLockTime(lockTime);
+                    lockTime = BondingConsensus.getLockTime(opReturnData);
                 });
     }
 

--- a/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -24,6 +24,7 @@ import bisq.core.dao.state.blockchain.TempTx;
 import bisq.core.dao.state.blockchain.TempTxOutput;
 import bisq.core.dao.state.blockchain.TxOutput;
 import bisq.core.dao.state.blockchain.TxOutputType;
+import bisq.core.dao.state.blockchain.TxType;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -105,7 +106,10 @@ public class TxOutputParser {
         byte[] opReturnData = tempTxOutput.getOpReturnData();
         if (opReturnData == null) {
             long txOutputValue = tempTxOutput.getValue();
-            if (isUnlockBondTx(tempTxOutput.getValue(), index)) {
+            if (tempTx.getTxType() == TxType.INVALID) {
+                // Set all non opReturn outputs to BTC_OUTPUT if the tx is invalid
+                tempTxOutput.setTxOutputType(TxOutputType.BTC_OUTPUT);
+            } else if (isUnlockBondTx(tempTxOutput.getValue(), index)) {
                 // We need to handle UNLOCK transactions separately as they don't follow the pattern on spending BSQ
                 // The LOCKUP BSQ is burnt unless the output exactly matches the input, that would cause the
                 // output to not be BSQ output at all

--- a/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxOutputParser.java
@@ -82,7 +82,7 @@ public class TxOutputParser {
         }
     }
 
-    boolean processOpReturnCandidate(TempTxOutput txOutput) {
+    boolean isOpReturnCandidate(TempTxOutput txOutput) {
         optionalOpReturnTypeCandidate = OpReturnParser.getOptionalOpReturnTypeCandidate(txOutput);
         return optionalOpReturnTypeCandidate.isPresent();
     }

--- a/src/main/java/bisq/core/dao/node/parser/TxParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxParser.java
@@ -116,7 +116,7 @@ public class TxParser {
             checkArgument(!outputs.isEmpty(), "outputs must not be empty");
             int lastIndex = outputs.size() - 1;
             int lastNonOpReturnIndex = lastIndex;
-            if (txOutputParser.processOpReturnCandidate(outputs.get(lastIndex))) {
+            if (txOutputParser.isOpReturnCandidate(outputs.get(lastIndex))) {
                 txOutputParser.processTxOutput(true, outputs.get(lastIndex), lastIndex);
                 lastNonOpReturnIndex -= 1;
             }

--- a/src/main/java/bisq/core/dao/node/parser/TxParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/TxParser.java
@@ -66,7 +66,7 @@ public class TxParser {
     }
 
     // Apply state changes to tx, inputs and outputs
-    // return true if any input contained BSQ
+    // return Tx if any input contained BSQ
     // Any tx with BSQ input is a BSQ tx (except genesis tx but that is not handled in
     // that class).
     // There might be txs without any valid BSQ txOutput but we still keep track of it,
@@ -143,7 +143,6 @@ public class TxParser {
 
             remainingInputValue = txOutputParser.getAvailableInputValue();
 
-            // TODO(SQ): If the tx is set to INVALID in this check the txOutputs stay valid
             processOpReturnType(blockHeight, tempTx);
 
             // TODO(SQ): Should the destroyed BSQ from an INVALID tx be considered as burnt fee?
@@ -169,6 +168,12 @@ public class TxParser {
                     String msg = "We have undefined txOutput types which must not happen. tx=" + tempTx;
                     DevEnv.logErrorAndThrowIfDevMode(msg);
                 }
+            }
+
+            if (tempTx.getTxType() != TxType.INVALID){
+                txOutputParser.commitTxOutputs();
+            } else {
+                txOutputParser.commitTxOutputsForInvalidTx();
             }
         }
 

--- a/src/main/java/bisq/core/dao/state/blockchain/Tx.java
+++ b/src/main/java/bisq/core/dao/state/blockchain/Tx.java
@@ -138,14 +138,12 @@ public final class Tx extends BaseTx implements PersistablePayload {
 
 
     /**
-     * OpReturn output might contain the lockTime in case of a LockTx. It has to be the last output.
-     * We store technically the lockTime there as is is stored in the OpReturn data but conceptually we want to provide
-     * it from the transaction.
+     * The locktime is stored in the LOCKUP txOutput, which is the first txOutput.
      *
      * @return
      */
     public int getLockTime() {
-        return getLastTxOutput().getLockTime();
+        return txOutputs.get(0).getLockTime();
     }
 
     @Override


### PR DESCRIPTION
Since the effects of opreturn act on the BSQ outputs it makes more sense
to parse the opreturn before parsing the remaining outputs.

Put the lock time in the LOCKUP txOutput. It makes more logical sense to
keep it there.